### PR TITLE
Extend config.redbrick with tld and skipVhosts

### DIFF
--- a/common/options.nix
+++ b/common/options.nix
@@ -1,0 +1,24 @@
+{ lib, ... }:
+{
+  options.redbrick = {
+    tld = lib.mkOption {
+      description = "Source of truth of TLD for entire Nix config";
+      default = "redbrick.dcu.ie";
+      type = lib.types.nullOr lib.types.str;
+    };
+
+    skipVhosts = lib.mkOption {
+      description = "Skip compiling the list of vhosts. Useful for development boxes";
+      default = false;
+      defaultText = "False (compile the vhosts)";
+      type = lib.types.nullOr lib.types.bool;
+    };
+
+    ldapSlaveTo = lib.mkOption {
+      description = "If this host is going to be an LDAP slave, set this to a hostname";
+      default = null;
+      defaultText = "Null (this is a master)";
+      type = lib.types.nullOr lib.types.str;
+    };
+  };
+}

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -1,7 +1,10 @@
 {config, pkgs, ...}:
 let
   common = import ./variables.nix;
+  tld = config.redbrick.tld;
 in {
+  imports = [ ./options.nix ];
+
   time.timeZone = "Europe/Dublin";
   i18n = {
     consoleFont = "Lat2-Terminus16";
@@ -16,8 +19,8 @@ in {
   ];
 
   # Use Redbrick DNS and HTTP proxy
-  networking.domain = common.tld;
-  networking.search = [ "internal" common.tld ];
+  networking.domain = tld;
+  networking.search = [ "internal" tld ];
   networking.nameservers = ["192.168.0.4"];
   networking.timeServers = ["192.168.0.254"];
   networking.proxy.default = "http://proxy.internal:3128/";

--- a/common/variables.nix
+++ b/common/variables.nix
@@ -1,6 +1,4 @@
 rec {
-  tld = "redbrick.dcu.ie";
-
   certsDir = "/var/lib/acme";
   webtreeCertsDir = "${certsDir}/.webroot";
   webtreeDir = "/storage/webtree";

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -33,6 +33,10 @@
     }];
   };
 
+  # Dev box, skip loading vhosts
+  redbrick.skipVhosts = true;
+  redbrick.tld = "redbricktest.ml";
+
   users.users.lucasade = {
     isNormalUser = true;
     home = "/home/lucasade";

--- a/services/certs/default.nix
+++ b/services/certs/default.nix
@@ -2,9 +2,10 @@
 with builtins;
 with lib;
 let
+  tld = config.redbrick.tld;
   common = import ../../common/variables.nix;
   vhosts = import ../httpd/vhosts.nix { inherit config; };
-  email = "webmaster+acme@${common.tld}";
+  email = "webmaster+acme@${tld}";
 
   # Filter *.dcu.ie domains
   vhostFilter = vhost:
@@ -22,11 +23,11 @@ in {
   ];
 
   security.acme.legoCerts = {
-    "${common.tld}" = {
+    "${tld}" = {
       inherit email;
       dnsProvider = "rfc2136";
       credentialsFile = "/var/secrets/certs.secret";
-      extraDomains."*.${common.tld}" = null;
+      extraDomains."*.${tld}" = null;
       extraFlags = [ "--dns.disable-cp" ];
     };
   } // (mapAttrs'

--- a/services/dns/default.nix
+++ b/services/dns/default.nix
@@ -1,11 +1,11 @@
-# Requires tsig-keygen dnsupdate.${common.tld} > /var/secrets/dnskeys.conf
+# Requires tsig-keygen dnsupdate.${tld} > /var/secrets/dnskeys.conf
 # chown named:root chmod 400
-{ lib, ... }:
+{ config, lib, ... }:
 let
-  common = import ../../common/variables.nix;
+  tld = config.redbrick.tld;
 
   keysPath = "/var/secrets/dnskeys.conf";
-  keyName = "dnsupdate.${common.tld}.";
+  keyName = "dnsupdate.${tld}.";
   zonePath = "/var/db/bind";
 in {
   # Enable eddsa support
@@ -33,7 +33,7 @@ in {
 
     zones = [
       {
-        # Not using common.tld here becaue we actually want to configure
+        # Not using tld here becaue we actually want to configure
         # a specific domain
         file = "${zonePath}/redbricktest.ml";
         master = true;

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -1,5 +1,7 @@
 {config, pkgs, ...}:
 let
+  tld = config.redbrick.tld;
+
   common = import ../../common/variables.nix;
 
   commonDovecot = import ./variables.nix;
@@ -22,8 +24,8 @@ in {
     enablePAM = false;
     showPAMFailure = false;
 
-    sslServerCert = "${common.certsDir}/${common.tld}/fullchain.pem";
-    sslServerKey = "${common.certsDir}/${common.tld}/key.pem";
+    sslServerCert = "${common.certsDir}/${tld}/fullchain.pem";
+    sslServerKey = "${common.certsDir}/${tld}/key.pem";
     sslCACert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
     mailUser = vmailUserName;

--- a/services/gitea.nix
+++ b/services/gitea.nix
@@ -1,6 +1,7 @@
-{ lib, ... }:
+{ config, lib, ... }:
 let
-  common = import ../common/variables.nix;
+  tld = config.redbrick.tld;
+
   secrets = import /var/secrets/gitea.nix;
   tokenPath = "/var/secrets/gitea_token.secret";
 
@@ -24,9 +25,9 @@ in {
     enable = true;
     appName = "Redbrick";
     user = "git";
-    domain = common.tld;
+    domain = tld;
     httpPort = 3000;
-    rootUrl = "https://git.${common.tld}/";
+    rootUrl = "https://git.${tld}/";
 
     database = {
       createDatabase = false;

--- a/services/httpd/default.nix
+++ b/services/httpd/default.nix
@@ -1,15 +1,16 @@
 { config, pkgs, ... }:
 let
+  tld = config.redbrick.tld;
   common = import ../../common/variables.nix;
   vhosts = import ./vhosts.nix { inherit config; };
   errorPages = import ../../packages/httpd-error-pages { inherit pkgs; };
-  adminAddr = "webmaster@${common.tld}";
+  adminAddr = "webmaster@${tld}";
 
   # Define a base vhost for all TLDs. This will serve only ACME on port 80
   # Everything else is promoted to HTTPS
   acmeVhost = {
     inherit adminAddr;
-    hostName = common.tld;
+    hostName = tld;
     serverAliases = ["*"];
     listen = [{ port = 80; }];
     documentRoot = common.webtreeCertsDir;
@@ -27,7 +28,7 @@ let
     documentRoot = "${common.webtreeDir}/redbrick/htdocs";
   in {
     inherit adminAddr documentRoot;
-    hostName = common.tld;
+    hostName = tld;
     listen = [{ port = 443; }];
     enableSSL = true;
     extraConfig = ''
@@ -35,10 +36,10 @@ let
       Alias /robots.txt "${common.webtreeDir}/redbrick/extras/robots.txt"
 
       # Redirect rb.dcu.ie/~user => user.rb.dcu.ie
-      RedirectMatch 301 "^/~([^/]*)/?(.*)$" "https://$1.${common.tld}/$2"
+      RedirectMatch 301 "^/~([^/]*)/?(.*)$" "https://$1.${tld}/$2"
 
       # Redirect /cmt to cmtwiki.rb
-      RedirectMatch 301 "^/cmt/wiki/?(.*)$" "https://cmtwiki.${common.tld}/$1"
+      RedirectMatch 301 "^/cmt/wiki/?(.*)$" "https://cmtwiki.${tld}/$1"
 
       <Directory ${documentRoot}>
         RewriteEngine on
@@ -86,8 +87,8 @@ in {
     extraModules = [ "suexec" "proxy" "proxy_fcgi" "ldap" "authnz_ldap" ];
     multiProcessingModule = "event";
     maxClients = 250;
-    sslServerKey = "${common.certsDir}/${common.tld}/key.pem";
-    sslServerCert = "${common.certsDir}/${common.tld}/fullchain.pem";
+    sslServerKey = "${common.certsDir}/${tld}/key.pem";
+    sslServerCert = "${common.certsDir}/${tld}/fullchain.pem";
 
     extraConfig = ''
       ProxyRequests off

--- a/services/httpd/mediawiki.nix
+++ b/services/httpd/mediawiki.nix
@@ -1,5 +1,5 @@
-{ pkgs, lib, ... }:
-with (import ./shared.nix);
+{ config, pkgs, lib, ... }:
+with (import ./shared.nix { tld = config.redbrick.tld; });
 let
   concatStringsSep = lib.strings.concatStringsSep;
 
@@ -180,7 +180,7 @@ let
   };
 
   wikiConfig = {
-    domain = "wiki.${common.tld}";
+    domain = "wiki.${tld}";
     title = "Redbrick Wiki";
     dbName = "wikinew";
     dbPrefix = "rbwiki_";
@@ -190,7 +190,7 @@ let
   wikiCfgPath = mkConfig wikiConfig;
 
   cmtWikiConfig = {
-    domain = "cmtwiki.${common.tld}";
+    domain = "cmtwiki.${tld}";
     title = "Redbrick Committee Wiki";
     dbName = "cmtwiki";
     dbPrefix = "wiki_";

--- a/services/httpd/privatebin.nix
+++ b/services/httpd/privatebin.nix
@@ -1,5 +1,5 @@
-{ pkgs, ... }:
-with (import ./shared.nix);
+{ config, pkgs, ... }:
+with (import ./shared.nix { tld = config.redbrick.tld; });
 let
   user = "paste";
   group = "redbrick";

--- a/services/httpd/shared.nix
+++ b/services/httpd/shared.nix
@@ -1,9 +1,9 @@
+{ tld }:
 let
   common = import ../../common/variables.nix;
 
   webtree = common.webtreeDir;
   home = common.homesDir;
-  tld = common.tld;
   adminAddr = "webmaster@${tld}";
 in {
   inherit common webtree home tld adminAddr;

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -1,5 +1,5 @@
 { config, ... }:
-with (import ./shared.nix);
+with (import ./shared.nix { tld = config.redbrick.tld; });
 let
   users = import ./users.nix;
 
@@ -12,7 +12,7 @@ let
     group = user.gid;
     serverAliases = [];
   }) users;
-in [
+in (if (config.redbrick.skipVhosts) then [] else ([
   (vhost {
     hostName = "abovethefold.es";
     documentRoot = "${webtree}/r/receive/abovethefold";
@@ -522,4 +522,4 @@ in [
   (vhostRedirect "techweek.${tld}" "https://techweek.dcu.ie")
   (vhostRedirect "tickets.${tld}" "https://dcusu.ticketsolve.com/shows/873599383/events/128190598")
   (vhostRedirect "ubuntu.${tld}" "https://wiki.redbrick.dcu.ie/mw/RedBrick_Ubuntu")
-] ++ userVhosts
+] ++ userVhosts))

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -8,8 +8,6 @@ let
   rootpwFile = "/var/secrets/ldap.secret";
   slurpdpwFile = "/var/secrets/slurpd.secret";
 in {
-  imports = [ ./options.nix ];
-
   services.openldap = {
     inherit rootpwFile;
     enable = true;

--- a/services/ldap/options.nix
+++ b/services/ldap/options.nix
@@ -1,9 +1,0 @@
-{ lib, ... }:
-{
-  options.redbrick.ldapSlaveTo = lib.mkOption {
-    description = "If this host is going to be an LDAP slave, set this to a hostname";
-    default = null;
-    defaultText = "Null (this is a master)";
-    type = lib.types.nullOr lib.types.str;
-  };
-}

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -1,5 +1,6 @@
 {config, pkgs, ...}:
 let
+  tld = config.redbrick.tld;
   common = import ../../common/variables.nix;
 
   ldapCommon = ''
@@ -12,7 +13,7 @@ let
     search_base = ou=accounts,o=redbrick
     query_filter = (&(objectClass=posixAccount)(uid=%u))
     result_attribute = uid
-    result_format = %s@${common.tld}
+    result_format = %s@${tld}
   '');
 
   commonRestrictions = [
@@ -29,13 +30,13 @@ in {
   services.postfix = {
     enable = true;
     setSendmail = true;
-    origin = common.tld;
-    hostname = "mail.${common.tld}";
-    destination = ["mail.${common.tld}" "localhost"];
+    origin = tld;
+    hostname = "mail.${tld}";
+    destination = ["mail.${tld}" "localhost"];
     recipientDelimiter = "+";
 
-    sslCert = "${common.certsDir}/${common.tld}/fullchain.pem";
-    sslKey = "${common.certsDir}/${common.tld}/key.pem";
+    sslCert = "${common.certsDir}/${tld}/fullchain.pem";
+    sslKey = "${common.certsDir}/${tld}/key.pem";
     sslCACert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
     # disable authentication on port 25. This port should only be used by other
@@ -60,7 +61,7 @@ in {
       # http://www.postfix.org/BASIC_CONFIGURATION_README.html#proxy_interfaces
       proxy_interfaces = "136.206.15.5";
 
-      virtual_mailbox_domains = "${common.tld}";
+      virtual_mailbox_domains = "${tld}";
       virtual_mailbox_maps = "hash:/var/lib/postfix/aliases";
       # virtual_alias_maps = "ldap:" ++ ./ldap-virtual-alias-maps.cf;
 


### PR DESCRIPTION
This makes it easier to set up a development host. Making tld an option allows it to be overridden on a per-host basis. Similarly skipVhosts allows you to not load the custom vhosts and skip ssl cert gen for prod domains.

Needed it to test mail branch.