### PR TITLE
Propolis: Use Prometheus and node-exporter to gather system metrics 

### DIFF
--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -24,7 +24,7 @@ in {
   networking.nameservers = ["192.168.0.4"];
   networking.timeServers = ["192.168.0.254"];
   networking.proxy.default = "http://proxy.internal:3128/";
-  networking.proxy.noProxy = "127.0.0.1,localhost,*.internal";
+  networking.proxy.noProxy = "127.0.0.1,localhost,192.168.0,.internal";
 
   # Enable rsyslog
   services.rsyslogd.enable = true;

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -33,6 +33,7 @@ in {
   # Enable Node exporter
   services.prometheus.exporters.node = {
     enable = true;
+    openFirewall = true;
     enabledCollectors = [
       "systemd"
       "conntrack"
@@ -51,7 +52,6 @@ in {
       "vmstat"
     ];
   };
-  networking.firewall.allowedTCPPorts = [ 9100 ];
 
   # Enable LDAP
   users.ldap.enable = true;

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -30,6 +30,29 @@ in {
   services.rsyslogd.enable = true;
   services.rsyslogd.extraConfig = "*.* @log.internal:6514;RSYSLOG_SyslogProtocol23Format";
 
+  # Enable Node exporter
+  services.prometheus.exporters.node = {
+    enable = true;
+    enabledCollectors = [
+      "systemd"
+      "conntrack"
+      "cpu"
+      "diskstats"
+      "entropy"
+      "filefd"
+      "filesystem"
+      "interrupts"
+      "loadavg"
+      "meminfo"
+      "netdev"
+      "netstat"
+      "stat"
+      "time"
+      "vmstat"
+    ];
+  };
+  networking.firewall.allowedTCPPorts = [ 9100 ];
+
   # Enable LDAP
   users.ldap.enable = true;
   users.ldap.timeLimit = 2;

--- a/hosts/butlerxvm/configuration.nix
+++ b/hosts/butlerxvm/configuration.nix
@@ -3,10 +3,7 @@
     ./hardware-configuration.nix
     ../../common/sysconfig.nix
     ../../services/ssh.nix
-    ../../services/postgres.nix
-    ../../services/loki.nix
-    ../../services/fluentd.nix
-    ../../services/grafana
+    ../../services/prometheus.nix
   ];
 
   # This value determines the NixOS release with which your system is to be

--- a/hosts/hardcase/configuration.nix
+++ b/hosts/hardcase/configuration.nix
@@ -13,6 +13,7 @@ in {
     ../../services/httpd
     ../../services/grafana
     ../../services/loki.nix
+    ../../services/prometheus.nix
     ../../services/fluentd.nix
   ];
 

--- a/packages/grafanaPlugin/default.nix
+++ b/packages/grafanaPlugin/default.nix
@@ -1,0 +1,37 @@
+{ pkgs, plugins, fetchurl ? pkgs.fetchurl, unzip ? pkgs.unzip }:
+
+let
+  fetchPlugins = { name, version ? "latest", ... } @ args: (fetchurl ({
+    inherit name;
+    url = "https://grafana.com/api/plugins/${name}/versions/${version}/download";
+    recursiveHash = true;
+    downloadToTemp = true;
+    postFetch = ''
+      unpackDir="$TMPDIR/unpack"
+      mkdir "$unpackDir"
+      cd "$unpackDir"
+      renamed="$TMPDIR/${name}.zip"
+      mv "$downloadedFile" "$renamed"
+      unpackFile "$renamed"
+      if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
+        echo "error: zip file must contain a single file or directory."
+        exit 1
+      fi
+      fn=$(cd "$unpackDir" && echo *)
+      if [ -f "$unpackDir/$fn" ]; then
+        mkdir $out
+      fi
+      mv "$unpackDir/$fn" "$out"
+    '';
+  } // removeAttrs args [ "version" ])).overrideAttrs (x: {
+    # Hackety-hack: we actually need unzip hooks, too
+    nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];
+  });
+in (map (plugin: {
+  name = plugin.name;
+  src = fetchPlugins ({
+    name = plugin.name;
+    version = plugin.version;
+    sha256 = plugin.sha256;
+  });
+}) plugins)

--- a/packages/grafanaPlugin/default.nix
+++ b/packages/grafanaPlugin/default.nix
@@ -12,21 +12,11 @@ let
       cd "$unpackDir"
       renamed="$TMPDIR/${name}.zip"
       mv "$downloadedFile" "$renamed"
-      unpackFile "$renamed"
-      if [ $(ls "$unpackDir" | wc -l) != 1 ]; then
-        echo "error: zip file must contain a single file or directory."
-        exit 1
-      fi
-      fn=$(cd "$unpackDir" && echo *)
-      if [ -f "$unpackDir/$fn" ]; then
-        mkdir $out
-      fi
-      mv "$unpackDir/$fn" "$out"
+      mkdir -p $out
+      ${unzip}/bin/unzip -d $out $renamed
+      mv "$unpackDir" "$out"
     '';
-  } // removeAttrs args [ "version" ])).overrideAttrs (x: {
-    # Hackety-hack: we actually need unzip hooks, too
-    nativeBuildInputs = x.nativeBuildInputs ++ [ unzip ];
-  });
+  } // removeAttrs args [ "version" ]));
 in (map (plugin: {
   name = plugin.name;
   src = fetchPlugins ({

--- a/services/dns/default.nix
+++ b/services/dns/default.nix
@@ -62,4 +62,10 @@ in {
 
   networking.firewall.allowedTCPPorts = [ 53 ];
   networking.firewall.allowedUDPPorts = [ 53 ];
+
+  # export metrics
+  services.prometheus.exporters.bind = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/services/grafana/default.nix
+++ b/services/grafana/default.nix
@@ -90,5 +90,5 @@ in {
   };
 
   systemd.services.grafana.preStart = lib.concatStringsSep "\n"
-    (map (plugin: "ln -fs ${plugin.src} ${dataDir}/plugins/${plugin.name}") plugins);
+    (map (plugin: "ln -fs ${plugin.src}/${plugin.name} ${dataDir}/plugins/") plugins);
 }

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -491,8 +491,10 @@ in (if (config.redbrick.skipVhosts) then [] else ([
     user = "yosarian";
     group = "associat";
   })
-  (vhostProxy "git.${tld}" "http://localhost:3000") # TODO: replace with service mapping to hardcase
-  (vhostProxy "graphs.${tld}" "http://localhost:3001") # TODO: replace with service mapping to hardcase
+  # TODO: replace with service mapping to hardcase
+  (vhostProxy "git.${tld}" "http://localhost:3000")
+  (vhostProxy "prometheus.${tld}" "http://localhost:9090")
+  (vhostProxy "graphs.${tld}" "http://localhost:3001")
   (vhostProxy "dcufm.${tld}" "http://136.206.16.136")
   (vhostProxy "jakarta.${tld}" "http://136.206.15.59:8080")
   (vhostProxy "macspayn.${tld}" "http://136.206.15.25:3007")

--- a/services/loki.nix
+++ b/services/loki.nix
@@ -40,10 +40,10 @@ in {
 
       storage_config = {
         boltdb = {
-          directory = "/var/loki/index";
+          directory = "${dataDir}/index";
         };
         filesystem = {
-          directory = "/var/loki/chunks";
+          directory = "${dataDir}/chunks";
         };
       };
 

--- a/services/loki.nix
+++ b/services/loki.nix
@@ -1,6 +1,6 @@
 { config, lib, ... }:
 let
-  dataDir = "/var/lib/loki";
+  dataDir = "/var/db/loki";
 in {
 
   services.loki = {

--- a/services/postgres.nix
+++ b/services/postgres.nix
@@ -3,4 +3,9 @@
     enable = true;
     dataDir = "/zroot/postgres";
   };
+
+  services.prometheus.exporters.postgres = {
+    enable = true;
+    openFirewall = true;
+  };
 }

--- a/services/prometheus.nix
+++ b/services/prometheus.nix
@@ -23,6 +23,10 @@ in {
         static_configs = [{ targets = ["localhost:9090"]; }];
       }
       {
+        job_name = "postgres";
+        static_configs = [{ targets = ["localhost:9187"]; }];
+      }
+      {
         job_name = "traefik";
         static_configs = [{ targets = ["zeus.internal:8080"]; }];
       }
@@ -33,6 +37,10 @@ in {
       {
         job_name = "gitea";
         static_configs = [{ targets = ["localhost:3000"]; }];
+      }
+      {
+        job_name = "bind";
+        static_configs = [{ targets = ["m1cr0man.internal:9119"]; }];
       }
       {
         # Only to be used with docker

--- a/services/prometheus.nix
+++ b/services/prometheus.nix
@@ -1,0 +1,50 @@
+{ config, lib, ... }:
+let
+  # We Should be able to generate this
+  nodes = [
+    "zeus"
+    "daedalus"
+    "icarus"
+    "hardcase"
+    "m1cr0man"
+    "butlerxvm"
+  ];
+  globalConfig = {
+    scrape_interval = "15s";
+    evaluation_interval = "15s";
+  };
+in {
+  services.prometheus = {
+    inherit globalConfig;
+    enable = true;
+    scrapeConfigs = [
+      {
+        job_name = "prometheus";
+        static_configs = [{ targets = ["localhost:9090"]; }];
+      }
+      {
+        job_name = "traefik";
+        static_configs = [{ targets = ["zeus.internal:8080"]; }];
+      }
+      {
+        job_name = "grafana";
+        static_configs = [{ targets = ["localhost:3001"]; }];
+      }
+      {
+        job_name = "gitea";
+        static_configs = [{ targets = ["localhost:3000"]; }];
+      }
+      {
+        # Only to be used with docker
+        job_name = "cadvisor";
+        static_configs = [{ targets = ["zeus.interal:8081"]; }];
+      }
+      {
+        job_name = "node-exporter";
+        static_configs = [{
+          targets = (map (node: "${node}.internal:9100") nodes);
+        }];
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Nixos has a large number of Prometheus exporters https://nixos.org/nixos/options.html#services.prometheus.exporters

The node exporter was previously used to monitor Zeus https://graphs.redbrick.dcu.ie/d/rYdddlPWk/server-overview?orgId=1 

This is a very detailed metric collector that can be easily extended. 
And more collectors can be easily added to Prometheus. 
