### PR TITLE
update ssh keys to follow schema - closes #35

### DIFF
--- a/services/ssh.nix
+++ b/services/ssh.nix
@@ -1,15 +1,15 @@
 {
   services.openssh.enable = true;
   users.users.root.openssh.authorizedKeys.keys = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnVLSh0OStxZTkXE6oGgwfFvsbvN6bFPlVfDYOwtnzn lucas@oatfield"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINnVLSh0OStxZTkXE6oGgwfFvsbvN6bFPlVfDYOwtnzn m1cr0man@@redbrick.dcu.ie"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPR+OTAIYr02f/WKQSXo7zYy9tkuAHYpy0ajqY6aJ7Nk m1cr0man@redbrick.dcu.ie"
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDYKnYP4Mmyk4wQE7J6Tyr27XToKtxAhXBZr5HkEXiFq root@gelandewagen"
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvabMrrJILDua2sedVqBStb6YKBHpgCO5HOM98l7uwf greenday@DESKTOP-NJVR3G4"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDYKnYP4Mmyk4wQE7J6Tyr27XToKtxAhXBZr5HkEXiFq m1cr0man@redbrick.dcu.ie"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvabMrrJILDua2sedVqBStb6YKBHpgCO5HOM98l7uwf greenday@redbrick.dcu.ie"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOjro8OS7cWf6xBcrs4erZqjN5JdztoGqpMXFQwzd9pV mctastic@azazel.redbrick.dcu.ie"
-    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLSLIF2IOo/OzbmbMGp4kt6VP2z8zNCuuVNyuxyBU0A8cOeUhkAbVibVmFqPlcHDJ4+zhkNN0GDnEJEUAmBNi+yc9EJG7StxdguEAKPlA9gQ/Z73cMrfMHtTPOHj/uCKUqi9vzb3tlOltJmuS3SwF0B5dk58j/cwr3nEEzikMmQIykxI+F+rxMnxaQXtNBGz3ednAaJ4Lvv9JSxWcExEtU0lM0X1MgZgkYFr48uQwsDUE+j23+wifMrOA+zhC0uRcuIapnxsyoW/wDOYrQZFlw6acrVX+zNtxcCQoqIX4oAobCXn7tYz9peKrV8TmJwQOspsmyY75xIAbyz0AiD3oh kyle@HP-Kyle"
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG/8Xf5/DtcOPjZKfag4ATBe5a3I1HvhYqi8fV7si4OU butlerx@notthe.cloud"
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLSLIF2IOo/OzbmbMGp4kt6VP2z8zNCuuVNyuxyBU0A8cOeUhkAbVibVmFqPlcHDJ4+zhkNN0GDnEJEUAmBNi+yc9EJG7StxdguEAKPlA9gQ/Z73cMrfMHtTPOHj/uCKUqi9vzb3tlOltJmuS3SwF0B5dk58j/cwr3nEEzikMmQIykxI+F+rxMnxaQXtNBGz3ednAaJ4Lvv9JSxWcExEtU0lM0X1MgZgkYFr48uQwsDUE+j23+wifMrOA+zhC0uRcuIapnxsyoW/wDOYrQZFlw6acrVX+zNtxcCQoqIX4oAobCXn7tYz9peKrV8TmJwQOspsmyY75xIAbyz0AiD3oh ylmcc@redbrick.dcu.ie"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIG/8Xf5/DtcOPjZKfag4ATBe5a3I1HvhYqi8fV7si4OU butlerx@redbrick.dcu.ie"
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIhA5mm1sBzz6tcrUF2FzW6wrckW1IsQAyS8Bfu4yJRJ d_fens@redbrick.dcu.ie"
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGybjW48+tQaykqDIuSeuH/3GLQRHZDa1toJOIB/FrD4 fraz@azazel.redbrick.dcu.ie"
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKVc8zqnZkzsOHzfycpJ3QbB9SJ2FxmRRifYbBuuixk2 galvinio@azazel.redbrick.dcu.ie"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGybjW48+tQaykqDIuSeuH/3GLQRHZDa1toJOIB/FrD4 fraz@redbrick.dcu.ie"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKVc8zqnZkzsOHzfycpJ3QbB9SJ2FxmRRifYbBuuixk2 galvinio@redbrick.dcu.ie"
   ];
 }


### PR DESCRIPTION
Each key in this PR corresponds to the respective Redbrick user of that key in the form <username>@redbrick.dcu.ie

The only key which doesn't use ssh-ed25519 required is ylmcc@redbrick.dcu.ie - I'm not sure how lenient we are on this, if needs be I can get him to generate an ed25519 key.