### PR TITLE
Remove more broken vhosts

### DIFF
--- a/common/variables.nix
+++ b/common/variables.nix
@@ -13,11 +13,9 @@ rec {
     "djbdns.now.ie" = "djbdns.now.ie";
     "romana.now.ie" = "djbdns.now.ie";
     "www.luxgaa.lu" = "www.luxgaa.lu";
-    "www.iahpc.ie" = "www.iahpc.ie";
     "techweek.dcu.ie" = "techweek.dcu.ie";
     "games.dcu.ie" = "www.games.dcu.ie";
     "www.games.dcu.ie" = "www.games.dcu.ie";
-    "interlan.dcu.ie" = "interlan.dcu.ie";
   };
 
   userWebtree = uid: "${webtreeDir}/${builtins.substring 0 1 uid}/${uid}";

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -159,11 +159,6 @@ in (if (config.redbrick.skipVhosts) then {} else userVhosts // {
     wwwRedirect = true;
     serverAliases = [ "www.halenger.com" ];
   };
-  "interlan.dcu.ie" = vhost {
-    documentRoot = "${webtree}/vhosts/www.interlan.dcu.ie";
-    user = "gamessoc";
-    group = "society";
-  };
   "gamessoc.${tld}" = vhost {
     documentRoot = "${webtree}/g/games";
     user = "gamessoc";
@@ -370,11 +365,6 @@ in (if (config.redbrick.skipVhosts) then {} else userVhosts // {
     group = "member";
     wwwRedirect = true;
     serverAliases = [ "www.ejmitchell.com" ];
-  };
-  "www.iahpc.ie" = vhost {
-    documentRoot = "${home}/guest/iahpc/public_html";
-    user = "iahpc";
-    group = "guest";
   };
   "www.luxgaa.lu" = vhost {
     documentRoot = "${webtree}/s/shivo/LuxGAA";


### PR DESCRIPTION
After renewing certs some more domains failed to validate due to DNS changes by owners. This removes those vhosts.