### PR TITLE
Convert mail stack

### DIFF
--- a/common/variables.nix
+++ b/common/variables.nix
@@ -38,10 +38,6 @@ rec {
     sslServerCert = "${certsDir}/${domain}/fullchain.pem";
   };
 
-  dovecotHost = "192.168.0.135";
-  dovecotSaslPort = 3659;
-  dovecotLmtpPort = 24;
-
   # Hard coded otherwise NSCD will crash systems during boot if network is down
   # 50 = daedalus
   ldapHostIp = "192.168.0.50";

--- a/hosts/hardcase/configuration.nix
+++ b/hosts/hardcase/configuration.nix
@@ -11,6 +11,8 @@ in {
     ../../services/thelounge.nix
     ../../services/certs
     ../../services/httpd
+    ../../services/postfix
+    ../../services/dovecot
     ../../services/grafana
     ../../services/loki.nix
     ../../services/prometheus.nix

--- a/hosts/hardcase/hardware-configuration.nix
+++ b/hosts/hardcase/hardware-configuration.nix
@@ -29,6 +29,13 @@
   systemd.targets.nfs-client.requiredBy = [ "storage.mount" ];
   systemd.targets.nfs-client.before = [ "storage.mount" ];
 
+  fileSystems."/var/spool/mail" =
+    { device = "icarus.internal:/zbackup/mail";
+      fsType = "nfs";
+    };
+  systemd.services.dovecot2.requires = [ "var-spool-mail.mount" ];
+  systemd.services.dovecot2.after = [ "var-spool-mail.mount" ];
+
   # zfs create -o dedup=off -o mountpoint=legacy -o recordsize=4K  zroot/postgres
   fileSystems."/var/db/postgres" =
     { device = "zroot/postgres";

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -17,7 +17,7 @@
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "19.09";
+  system.stateVersion = "20.09";
 
   # Use the GRUB 2 boot loader.
   boot.loader.grub.enable = true;
@@ -36,7 +36,7 @@
 
   # Dev box, skip loading vhosts
   redbrick.tld = "redbricktest.ml";
-  security.acme.server = "https://acme-staging-v02.api.letsencrypt.org/directory";
+  redbrick.skipCustomVhosts = true;
 
   users.users.lucasade = {
     isNormalUser = true;

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -9,7 +9,6 @@
     ../../services/postfix
     ../../services/dovecot
     ../../services/certs
-    ../../services/thelounge.nix
     ../../services/postgres.nix
   ];
 

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -35,8 +35,8 @@
   };
 
   # Dev box, skip loading vhosts
-  redbrick.skipVhosts = true;
   redbrick.tld = "redbricktest.ml";
+  security.acme.server = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
   users.users.lucasade = {
     isNormalUser = true;

--- a/hosts/m1vm/hardware-configuration.nix
+++ b/hosts/m1vm/hardware-configuration.nix
@@ -24,6 +24,13 @@
   systemd.targets.nfs-client.requiredBy = [ "storage.mount" ];
   systemd.targets.nfs-client.before = [ "storage.mount" ];
 
+  fileSystems."/var/spool/mail" =
+    { device = "icarus.internal:/zbackup/mailtest";
+      fsType = "nfs";
+    };
+  systemd.services.dovecot2.requires = [ "var-spool-mail.mount" ];
+  systemd.services.dovecot2.after = [ "var-spool-mail.mount" ];
+
   swapDevices =
     [ { device = "/dev/disk/by-uuid/7ca217d6-538e-4919-a57f-c5cbaeb93832"; }
     ];

--- a/nixops.nix
+++ b/nixops.nix
@@ -1,0 +1,5 @@
+{
+  icarus = { config, pkgs, ... }: {
+    deployment.targetHost = "192.168.0.150";
+  };
+}

--- a/services/dns/redbricktest.ml
+++ b/services/dns/redbricktest.ml
@@ -1,7 +1,7 @@
 $ORIGIN redbricktest.ml.
 $TTL 300
 @       IN      SOA     ns1.redbricktest.ml.     admins.redbricktest.ml. (
-                        2019060506      ; Serial
+                        2019060507      ; Serial
                         1M              ; Slave refresh interval
                         5M              ; Query retry interval
                         1H              ; Expiry
@@ -20,3 +20,4 @@ mail            IN      A       136.206.15.5
 
 www             IN      CNAME   server1
 wiki            IN      CNAME   server1
+lists           IN      CNAME   mail

--- a/services/dovecot/auth.nix
+++ b/services/dovecot/auth.nix
@@ -1,4 +1,4 @@
-{common, pkgs, vmailUserName, ...}:
+{common, pkgs, ...}:
 let
   bindCreds = import /var/secrets/dovecot_auth.nix;
 

--- a/services/dovecot/auth.nix
+++ b/services/dovecot/auth.nix
@@ -15,7 +15,7 @@ let
     user_filter = (&(objectclass=posixAccount)(uid=%n))
     pass_attrs = uid=uid,homeDirectory=home,userPassword=password
     pass_filter = (&(objectclass=posixAccount)(uid=%n))
-    iterate_attrs = homeDirectory=home
+    iterate_attrs = =user=%{ldap:uid}
     iterate_filter = (objectClass=posixAccount)
     default_pass_scheme = CRYPT
   '';

--- a/services/dovecot/auth.nix
+++ b/services/dovecot/auth.nix
@@ -11,7 +11,7 @@ let
     base = ou=accounts,o=redbrick
     deref = never
     scope = subtree
-    user_attrs = homeDirectory=home
+    user_attrs = uid=uid,homeDirectory=home
     user_filter = (&(objectclass=posixAccount)(uid=%n))
     pass_attrs = uid=uid,homeDirectory=home,userPassword=password
     pass_filter = (&(objectclass=posixAccount)(uid=%n))
@@ -41,9 +41,8 @@ in pkgs.writeText "dovecot-auth-config" ''
     args = ${ldapConfig}
   }
 
-  # The home field here will never be used, since none of our configs reference ~
   userdb {
-    driver = static
-    args = uid=vmail gid=vmail home=/var/empty
+    driver = ldap
+    args = ${ldapConfig}
   }
 ''

--- a/services/dovecot/auth.nix
+++ b/services/dovecot/auth.nix
@@ -1,4 +1,4 @@
-{common, pkgs, ...}:
+{common, pkgs, tld, ...}:
 let
   bindCreds = import /var/secrets/dovecot_auth.nix;
 
@@ -11,10 +11,12 @@ let
     base = ou=accounts,o=redbrick
     deref = never
     scope = subtree
-    user_attrs = uid=uid,homeDirectory=home
+    user_attrs = homeDirectory=home
     user_filter = (&(objectclass=posixAccount)(uid=%n))
     pass_attrs = uid=uid,homeDirectory=home,userPassword=password
     pass_filter = (&(objectclass=posixAccount)(uid=%n))
+    iterate_attrs = homeDirectory=home
+    iterate_filter = (objectClass=posixAccount)
     default_pass_scheme = CRYPT
   '';
 
@@ -24,8 +26,14 @@ in pkgs.writeText "dovecot-auth-config" ''
   auth_cache_ttl = 1 hour
   auth_cache_negative_ttl = 1 hour
 
+  # Set domain for login names without a domain specified
+  auth_default_realm = ${tld}
+
   # only use plain username/password auth - OK since everything is over TLS
   auth_mechanisms = plain
+
+  # Don't strip domain from username. Means that mail_location can reference %d
+  auth_username_format = %Lu
 
   # passdb specifies how users are authenticated - LDAP in my case
   passdb {
@@ -33,8 +41,9 @@ in pkgs.writeText "dovecot-auth-config" ''
     args = ${ldapConfig}
   }
 
+  # The home field here will never be used, since none of our configs reference ~
   userdb {
-    driver = ldap
-    args = ${ldapConfig}
+    driver = static
+    args = uid=vmail gid=vmail home=/var/empty
   }
 ''

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -6,7 +6,7 @@ let
 
   sieveConfig = import ./sieve.nix { inherit pkgs; };
   authConfig = import ./auth.nix { inherit common pkgs tld; };
-  masterConfig = import ./master.nix { inherit common pkgs; };
+  masterConfig = import ./master.nix { inherit pkgs; };
 
   # Fixed uid + gid so that the config can roam systems safely
   vmailId = 975;
@@ -25,7 +25,7 @@ let
   });
 
 in {
-  networking.firewall.allowedTCPPorts = [ 993 common.dovecotSaslPort common.dovecotLmtpPort ];
+  networking.firewall.allowedTCPPorts = [ 993 ];
 
   security.dhparams.enable = true;
   # Name found in https://github.com/NixOS/nixpkgs/blob/d7752fc0ebf9d49dc47c70ce4e674df024a82cfa/nixos/modules/services/mail/dovecot.nix#L26

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -1,4 +1,3 @@
-# ENSURE /var/mail IS CHMOD 3770
 {config, pkgs, ...}:
 let
   tld = config.redbrick.tld;
@@ -68,6 +67,8 @@ in {
     mailUser = "vmail";
     mailGroup = "vmail";
 
+    # ENSURE /var/mail IS CHMOD 3770
+    # See https://wiki.dovecot.org/SharedMailboxes/Permissions
     mailLocation = "mdbox:/var/mail/%d/%n";
 
     mailboxes = [{

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -4,12 +4,23 @@ let
 
   common = import ../../common/variables.nix;
 
-  commonDovecot = import ./variables.nix;
-
-  vmailUserName = "vmail";
-
-  authConfig = import ./auth.nix { inherit common pkgs vmailUserName; };
+  sieveConfig = import ./sieve.nix { inherit pkgs; };
+  authConfig = import ./auth.nix { inherit common pkgs; };
   masterConfig = import ./master.nix { inherit common pkgs; };
+
+  # Fix mtime comparison so that scripts can be precompiled
+  # See https://github.com/NixOS/nixpkgs/pull/35536/files
+  # and https://github.com/dovecot/pigeonhole/pull/4
+  pigeonhole = pkgs.dovecot_pigeonhole.overrideAttrs (old: {
+    patches = [
+      (pkgs.fetchpatch {
+        name = "binary-mtime.patch";
+        url = https://github.com/dovecot/pigeonhole/commit/3defbec146e195edad336a2c218f108462b0abd7.patch;
+        sha256 = "09mvdw8gjzq9s2l759dz4aj9man8q1akvllsq2j1xa2qmwjfxarp";
+      })
+    ];
+  });
+
 in {
   networking.firewall.allowedTCPPorts = [ 993 common.dovecotSaslPort common.dovecotLmtpPort ];
 
@@ -17,8 +28,13 @@ in {
   # Name found in https://github.com/NixOS/nixpkgs/blob/d7752fc0ebf9d49dc47c70ce4e674df024a82cfa/nixos/modules/services/mail/dovecot.nix#L26
   security.dhparams.params.dovecot2.bits = 2048;
 
+  # Increase ulimit due to service_auth client_limit (2000)
+  systemd.services.dovecot2.serviceConfig.LimitNOFILE = 2500;
+
   services.dovecot2 = {
     enable = true;
+    modules = [ pigeonhole ];
+
     enableImap = true;
     enableLmtp = true;
     enablePAM = false;
@@ -30,9 +46,11 @@ in {
 
     # We don't want all members to be able to read other member's mail
     # Force a specific group
-    mailGroup = vmailUserName;
+    createMailUser = false;
+    mailUser = "dovecot2";
+    mailGroup = "dovecot2";
 
-    mailLocation = "mdbox:~/mdbox";
+    mailLocation = "mdbox:/var/mail/%d/%n";
 
     mailboxes = [{
       name = "Junk";
@@ -49,13 +67,9 @@ in {
     }];
 
     extraConfig = ''
-      # to improve performance, disable fsync globally - we will enable it for
-      # some specific services later on
-      mail_fsync = never
-
-      auth_verbose = yes
-
-      mail_debug = yes
+      # Having trouble? Try enabling these
+      auth_verbose = no
+      mail_debug = no
 
       namespace inbox {
         separator = /
@@ -66,18 +80,18 @@ in {
         # max IMAP connections per IP address
         mail_max_userip_connections = 50
         # imap_sieve will be used for spam training by rspamd
-        mail_plugins = $mail_plugins # imap_sieve
+        mail_plugins = $mail_plugins imap_sieve
       }
 
       protocol lmtp {
         mail_fsync = optimized
-        mail_plugins = $mail_plugins
+        mail_plugins = $mail_plugins sieve
       }
 
       # require SSL for all non-localhost connections
       ssl = required
 
-      mail_home = /var/mail/%n
+      mail_home = /var/mail/%d/%n
       mail_attachment_dir = /var/mail/attachments
       mail_attachment_min_size = 64k
 
@@ -94,23 +108,9 @@ in {
       !include ${masterConfig}
 
       # Enable sieve scripts
-      # protocols = $protocols sieve
+      protocols = $protocols sieve
 
-      # plugin {
-        # location of users' sieve directory and their "active" sieve script
-        # sieve = file:~/sieve;active=~/.dovecot.sieve
-
-        # directory of global sieve scripts to run before and after processing ALL
-        # incoming mail
-        # sieve_before = /usr/local/etc/dovecot/sieve-before.d
-        # sieve_after  = /usr/local/etc/dovecot/sieve-after.d
-
-        # make sieve aware of user+tag@domain.tld aliases
-        # recipient_delimiter = +
-
-        # maximum size of all user's sieve scripts
-        # sieve_quota_max_storage = 10M
-      # }
+      !include ${sieveConfig}
     '';
   };
 }

--- a/services/dovecot/master.nix
+++ b/services/dovecot/master.nix
@@ -1,4 +1,4 @@
-{common, pkgs, ...}:
+{pkgs, ...}:
 pkgs.writeText "dovecot-master-config" ''
 service imap-login {
   # plain-text IMAP should only be accessible from localhost
@@ -25,23 +25,31 @@ service pop3-login {
 
 # enable semi-long-lived IMAP processes to improve performance
 service imap {
-  service_count = 256
-  # set to the number of CPU cores on your server
-  process_min_avail = 3
+  # Service count must be 1 to prevent imap uid leaking and setuid issues
+  # Seen as "imap(foo)<5288><JWXxCE2ks4ZZE0NM>: Fatal: setuid(foo from userdb lookup) failed with euid=bar: Operation not permitted"
+  # See https://doc.dovecot.org/configuration_manual/service_configuration/
+  # Docs specify you should just do this if you have multiple UIDs
+  service_count = 1
+  process_limit = 2000
 }
 
 # Listen on LMTP port for postfix to deliver mail
 service lmtp {
-  inet_listener {
-    port = ${builtins.toString common.dovecotLmtpPort}
+  client_limit = 1
+  unix_listener /var/run/dovecot2_lmtp.sock {
+    user = postfix
+    group = postfix
+    mode = 0600
   }
 }
 
 # Listen on auth socket for postfix to authenticate users
 service auth {
   client_limit = 2000
-  inet_listener {
-    port = ${builtins.toString common.dovecotSaslPort}
+  unix_listener /var/run/dovecot2_sasl.sock {
+    user = postfix
+    group = postfix
+    mode = 0600
   }
 }
 ''

--- a/services/dovecot/master.nix
+++ b/services/dovecot/master.nix
@@ -1,9 +1,5 @@
 {common, pkgs, ...}:
 pkgs.writeText "dovecot-master-config" ''
-# to improve performance, disable fsync globally - we will enable it for
-# some specific services later on
-mail_fsync = never
-
 service imap-login {
   # plain-text IMAP should only be accessible from localhost
   inet_listener imap {
@@ -43,6 +39,7 @@ service lmtp {
 
 # Listen on auth socket for postfix to authenticate users
 service auth {
+  client_limit = 2000
   inet_listener {
     port = ${builtins.toString common.dovecotSaslPort}
   }

--- a/services/dovecot/sieve.nix
+++ b/services/dovecot/sieve.nix
@@ -1,0 +1,134 @@
+{pkgs}:
+with pkgs.stdenv;
+let
+
+  # These scripts are used by the imapsieve plugin to learn spam and ham
+  learnSpamScript = pkgs.writeShellScript "learn-spam.sh" ''
+    ${pkgs.rspamd}/bin/rspamc -h /run/rspamd/rspamd.sock learn_spam
+  '';
+
+  learnHamScript = pkgs.writeShellScript "learn-ham.sh" ''
+    ${pkgs.rspamd}/bin/rspamc -h /run/rspamd/rspamd.sock learn_ham
+  '';
+
+  sievePipeBinaries = mkDerivation {
+    name = "sieve-pipe-binaries";
+
+    phases = [ "copyPhase" "fixupPhase" ];
+
+    copyPhase = ''
+      mkdir -p $out/bin
+      cp -a ${learnHamScript} $out/bin/learn-ham.sh
+      cp -a ${learnSpamScript} $out/bin/learn-spam.sh
+    '';
+  };
+
+  # sieve-before script to put spam into Junk folder
+  spamFilter = pkgs.writeText "spam-filter.sieve" ''
+    require ["fileinto"];
+
+    if header :is "X-Spam" "Yes" {
+      fileinto "Junk";
+    }
+  '';
+
+  # imapsieve script to detect when a user marks an email as spam
+  reportSpamFilter = pkgs.writeText "report-spam.sieve" ''
+    require ["vnd.dovecot.pipe", "copy", "imapsieve", "environment", "variables"];
+
+    if environment :matches "imap.email" "*" {
+      set "email" "''${1}";
+    }
+
+    pipe :copy "learn-spam.sh" [ "''${email}" ];
+  '';
+
+  # imapsieve script to detect when a user moves an email out of spam
+  reportHamFilter = pkgs.writeText "report-ham.sieve" ''
+    require ["vnd.dovecot.pipe", "copy", "imapsieve", "environment", "variables"];
+
+    if environment :matches "imap.mailbox" "*" {
+      set "mailbox" "''${1}";
+    }
+
+    if string "''${mailbox}" "Trash" {
+      stop;
+    }
+
+    if environment :matches "imap.email" "*" {
+      set "email" "''${1}";
+    }
+
+    pipe :copy "learn-ham.sh" [ "''${email}" ];
+  '';
+
+  sieveSimpleConfig = ''
+    sieve_plugins = sieve_imapsieve sieve_extprograms
+    sieve_global_extensions = +vnd.dovecot.pipe
+    sieve_pipe_bin_dir = ${sievePipeBinaries}/bin
+  '';
+
+  sieveCompileConfig = pkgs.writeText "sieve-compile-config" ''
+    plugin {
+    ${sieveSimpleConfig}
+    }
+  '';
+
+  sieveScripts = mkDerivation {
+    name = "sieve-scripts";
+
+    buildInputs = [ pkgs.dovecot_pigeonhole ];
+
+    phases = [ "copyPhase" ];
+
+    copyPhase = ''
+      mkdir -p $out/{before,after,imap}
+      cd $out/before
+      cp ${spamFilter} spam-filter.sieve
+      sievec -c "${sieveCompileConfig}" spam-filter.sieve
+      cd $out/imap
+      cp ${reportSpamFilter} report-spam.sieve
+      cp ${reportHamFilter} report-ham.sieve
+      sievec -c "${sieveCompileConfig}" report-spam.sieve
+      sievec -c "${sieveCompileConfig}" report-ham.sieve
+    '';
+
+    meta = with lib; {
+      description = "Redbrick compiled sieve scripts for Dovecot";
+      platforms = platforms.linux;
+      maintainers = [ maintainers.m1cr0man ];
+    };
+  };
+
+in pkgs.writeText "dovecot-sieve-config" ''
+  plugin {
+    ${sieveSimpleConfig}
+
+    # location of users' sieve directory and their "active" sieve script
+    sieve = file:~/sieve;active=~/.dovecot.sieve
+
+    # directory of global sieve scripts to run before and after processing ALL
+    # incoming mail
+    sieve_before = ${sieveScripts}/before
+    sieve_after  = ${sieveScripts}/after
+
+    # make sieve aware of user+tag@domain.tld aliases
+    recipient_delimiter = +
+
+    # maximum size of all user's sieve scripts
+    sieve_quota_max_storage = 2M
+
+    ## Spam and Ham learning ##
+
+    # From elsewhere to Junk folder
+    imapsieve_mailbox1_name = Junk
+    imapsieve_mailbox1_causes = COPY
+    imapsieve_mailbox1_before = file:${sieveScripts}/imap/report-spam.sieve
+
+    # From Junk folder to elsewhere
+    imapsieve_mailbox2_name = *
+    imapsieve_mailbox2_from = Junk
+    imapsieve_mailbox2_causes = COPY
+    imapsieve_mailbox2_before = file:${sieveScripts}/imap/report-ham.sieve
+  }
+''

--- a/services/dovecot/variables.nix
+++ b/services/dovecot/variables.nix
@@ -1,3 +1,0 @@
-{
-    configPath = "/etc/dovecot.d";
-}

--- a/services/httpd/default.nix
+++ b/services/httpd/default.nix
@@ -1,10 +1,8 @@
 { config, pkgs, lib, ... }:
+with (import ./shared.nix { tld = config.redbrick.tld; });
 let
-  tld = config.redbrick.tld;
-  common = import ../../common/variables.nix;
   vhosts = import ./vhosts.nix { inherit config; };
   errorPages = import ../../packages/httpd-error-pages { inherit pkgs; };
-  adminAddr = "webmaster@${tld}";
 
   # Define a base vhost for all TLDs. This will serve only ACME on port 80
   # Everything else is promoted to HTTPS
@@ -67,6 +65,7 @@ in {
     ./php-fpm.nix
     ./mediawiki.nix
     ./privatebin.nix
+    ./mailman.nix
   ];
 
   # Enable suexec support
@@ -120,7 +119,6 @@ in {
       </Directory>
 
       AddHandler cgi-script .cgi
-      AddHandler cgi-script .py
       AddHandler cgi-script .sh
       AddHandler server-parsed .shtml
       AddHandler server-parsed .html

--- a/services/httpd/mailman.nix
+++ b/services/httpd/mailman.nix
@@ -13,6 +13,7 @@ let
 
   vhostConfig = {
     adminAddr = "webmaster@${tld}";
+    serverAliases = [ "localmail.${tld}" ];
     servedDirs = [ { dir = "${generatedDataPath}/static"; urlPath = "/static"; } ];
     extraConfig = ''
       <Location /accounts/signup>
@@ -41,8 +42,5 @@ in {
     '';
 
     virtualHosts."lists.${tld}" = vhostConfig // { onlySSL = true; } // (vhostCerts tld);
-
-    # Alias for mailman local access to hyperkitty
-    virtualHosts."lists.local" = vhostConfig;
   };
 }

--- a/services/httpd/mailman.nix
+++ b/services/httpd/mailman.nix
@@ -1,0 +1,44 @@
+# Manual steps post-deploy:
+# cd /var/lib/mailman-web && sudo -u wwwrun mailman-web createsuperuser
+{ pkgs, lib, config, ... }:
+with (import ./shared.nix { tld = config.redbrick.tld; });
+let
+  webRoot = config.services.mailman.webRoot;
+  generatedDataPath = "/var/lib/mailman-web";
+
+  # Build mod_wsgi with python3
+  wsgiPkg = with pkgs; mod_wsgi.overrideAttrs (oldAttrs: {
+    buildInputs = [ apacheHttpd python3 ncurses ];
+  });
+
+  vhostConfig = {
+    adminAddr = "webmaster@${tld}";
+    servedDirs = [ { dir = "${generatedDataPath}/static"; urlPath = "/static"; } ];
+    extraConfig = ''
+      <Directory "${webRoot}">
+        Options ExecCGI
+        <Files wsgi.py>
+          Require all granted
+        </Files>
+        WSGIProcessGroup mailman
+      </Directory>
+      WSGIScriptAlias / ${webRoot}/mailman_web/wsgi.py
+    '';
+  };
+in {
+  services.httpd = {
+    extraModules = [ { name = "wsgi"; path = "${wsgiPkg}/modules/mod_wsgi.so"; } ];
+    extraConfig = ''
+      WSGISocketPrefix /run/httpd/wsgi
+      WSGIDaemonProcess mailman threads=4 home=${generatedDataPath} python-path=/etc/mailman3:${webRoot}:${
+        lib.makeSearchPath pkgs.python3.sitePackages
+          pkgs.python3Packages.mailman-web.requiredPythonModules
+      }
+    '';
+
+    virtualHosts."lists.${tld}" = vhostConfig // { onlySSL = true; } // (vhostCerts tld);
+
+    # Alias for mailman local access to hyperkitty
+    virtualHosts."lists.local" = vhostConfig;
+  };
+}

--- a/services/httpd/mailman.nix
+++ b/services/httpd/mailman.nix
@@ -15,6 +15,10 @@ let
     adminAddr = "webmaster@${tld}";
     servedDirs = [ { dir = "${generatedDataPath}/static"; urlPath = "/static"; } ];
     extraConfig = ''
+      <Location /accounts/signup>
+        Order allow,deny
+        Deny from all
+      </Location>
       <Directory "${webRoot}">
         Options ExecCGI
         <Files wsgi.py>

--- a/services/httpd/mediawiki.nix
+++ b/services/httpd/mediawiki.nix
@@ -160,7 +160,7 @@ let
     <Directory "${config.stateDir}">
       Require all granted
     </Directory>
-  '';}) // (common.vhostCerts tld);
+  '';}) // (vhostCerts tld);
 
   # Adapted from the nixpkgs repo mediawiki implementation
   # Skips initial setup, this will never be done at RB. Feel free to port it if you think it will.

--- a/services/httpd/mediawiki.nix
+++ b/services/httpd/mediawiki.nix
@@ -160,7 +160,7 @@ let
     <Directory "${config.stateDir}">
       Require all granted
     </Directory>
-  '';}) // (vhostCerts tld);
+  '';}) // (common.vhostCerts tld);
 
   # Adapted from the nixpkgs repo mediawiki implementation
   # Skips initial setup, this will never be done at RB. Feel free to port it if you think it will.

--- a/services/httpd/privatebin.nix
+++ b/services/httpd/privatebin.nix
@@ -8,7 +8,7 @@ in {
     inherit user group;
     documentRoot = import ../../packages/privatebin {inherit pkgs;};
     extraConfig = "SetEnv CONFIG_PATH ${./conf.php}";
-  }) // (vhostCerts tld);
+  }) // (common.vhostCerts tld);
   systemd.tmpfiles.rules = [
     "d '/var/lib/privatebin' 0750 ${user} ${group} - -"
   ];

--- a/services/httpd/privatebin.nix
+++ b/services/httpd/privatebin.nix
@@ -8,7 +8,7 @@ in {
     inherit user group;
     documentRoot = import ../../packages/privatebin {inherit pkgs;};
     extraConfig = "SetEnv CONFIG_PATH ${./conf.php}";
-  }) // (common.vhostCerts tld);
+  }) // (vhostCerts tld);
   systemd.tmpfiles.rules = [
     "d '/var/lib/privatebin' 0750 ${user} ${group} - -"
   ];

--- a/services/httpd/shared.nix
+++ b/services/httpd/shared.nix
@@ -52,4 +52,9 @@ in {
       ProxyPassReverse / ${proxyAddress}/
     '';
   };
+
+  vhostCerts = domain: {
+    sslServerKey = "${common.certsDir}/${domain}/key.pem";
+    sslServerCert = "${common.certsDir}/${domain}/fullchain.pem";
+  };
 }

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -214,7 +214,6 @@ in (userVhosts // {
   "graphs.${tld}" = vhostProxy "http://localhost:3001";
   "dcufm.${tld}" = vhostProxy "http://136.206.15.74";
   "jakarta.${tld}" = vhostProxy "http://136.206.15.59:8080";
-  "lists.${tld}" = vhostProxy "http://mail.internal:80";
   "macspayn.${tld}" = vhostProxy "http://136.206.15.25:3007";
   "portaldev.${tld}" = vhostProxy "http://136.206.15.61:9080";
   "radio.${tld}" = vhostProxy "http://radio.${tld}:8000";

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -9,6 +9,7 @@ let
     "paste"
     "wiki"
     "cmtwiki"
+    "lists"
   ];
 
   # This is appended at the top

--- a/services/httpd/vhosts.nix
+++ b/services/httpd/vhosts.nix
@@ -236,6 +236,7 @@ in (userVhosts // {
   "help.${tld}" = vhostRedirect "https://wiki.${tld}/mw/Helpdesk";
   "helpdesk.${tld}" = vhostRedirect "https://wiki.${tld}/mw/Helpdesk";
   "helpdeskexam.${tld}" = vhostRedirect "https://md.${tld}/s/SJzip7F9X#";
+  "mail.${tld}" = vhostRedirect "https://webmail.${tld}";
   "hoodies.${tld}" = vhostRedirect "https://redbrickdcu.typeform.com/to/Q4uIzR";
   "parlour.${tld}" = vhostRedirect "https://songsfromtheparlour.com";
   "sistem.${tld}" = vhostRedirect "https://sistem.intersocs.ie";

--- a/services/postfix/aliases.nix
+++ b/services/postfix/aliases.nix
@@ -1,0 +1,589 @@
+{tld}:
+{
+#
+# System, committee and important email aliases.
+#
+# $Id: aliases,v 1.18 2015/11/18 19:16:50 koffee Exp koffee $
+#
+
+#
+# NOTES
+# =====
+# - For committee position aliases during the changeover period, list the
+#   outgoing person(s) first followed by the incoming person(s).
+#
+
+
+#-----------------#
+# SYSTEM ACCOUNTS #
+#-----------------#
+
+
+# Redirections for system and pseudo accounts.
+#
+  "MAILER-DAEMON" = "postmaster";
+  "postmaster" = "root";
+  "bin" = "root";
+  "daemon" = "root";
+  "man" = "root";
+  "news" = "root";
+  "nobody" = "/dev/null";
+  "operator" = "root";
+  "pop" = "root";
+  "system" = "root";
+  "toor" = "root";
+  "usenet" = "news";
+  "uucp" = "root";
+  "xten" = "root";
+  "postfix" = "root";
+  "abuse" = "rb-admins,chair,sec";
+  "security" = "root";
+  "ftp" = "root";
+  "ftp-bugs" = "ftp";
+  "hostmaster" = "root";
+  "nagios" = "root";
+  "_nagios" = "root";
+  "ossec" = "root";
+
+# Mailman
+#
+  "mailman" = "root";
+  "mailman-owner" = "mailman";
+  "mailman-request" = "mailman";
+  "mailman-bounces" = "mailman";
+  "mailman-admin" = "mailman";
+
+# Where root mail goes. VERY IMPORTANT!
+#
+  "root" = "rb-admins";
+
+#bit-bucket:		/dev/null
+#dev-null:		bit-bucket
+
+
+#----------------#
+# Administrators #
+#----------------#
+
+# Who wants to get system reports, cron job output etc.
+#
+  "system-reports" = "rb-admins";
+  "audit_warn" = "system-reports";
+
+# Offical way to contact admins for requests.
+#
+  "admin-request" = "rb-admins, ticket";
+  "elected-admin" = "elected-admins";
+
+# Where mail addressed to generic 'admins' goes.
+#
+  "admin" = "admin-request";
+  "admins" = "admin-request";
+
+# DCU admin list.
+#
+# <plop>: Thu May 28 11:07:05 BST 1998
+#
+  "dcu-admin-list" = "rb-admins, sysops@dcu.ie, mcgorman@compapp.dcu.ie";
+
+
+#-------------#
+# Web related #
+#-------------#
+
+# webmaster is now a mailman list
+
+  "httpd" = "webmaster";
+  "www" = "webmaster";
+
+
+#---------------------#
+# Committee & Society #
+#---------------------#
+
+
+# "The Founders" (TM)
+#
+  "founders" = "drjolt, wibble, sandman, fergus, swipe, hyper";
+
+# Committee is now a mailing list (handled by mailman)
+#
+
+# HELP! requests.
+#
+  "help" = "helpdesk";
+  "support" = "helpdesk";
+  "help-request" = "helpdesk";
+  "helpdesk-request" = "helpdesk";
+  "faildesk" = "helpdesk";
+  "thosecunts" = "helpdesk";
+
+# Chairperson alias.
+#
+  "chairperson" = "chair";
+  "failchair" = "chair";
+
+# Treasurer alias.
+#
+  "treasurer" = "treasure";
+
+# Secretary alias.
+#
+  "secretary" = "sec";
+  "failsec" = "sec";
+
+# PRO alias.
+#
+  "profail" = "pro";
+
+# Ents alias.
+#
+  "ents" = "events";
+  "failents" = "events";
+  "birthday" = "events";
+
+# Webmaster aliass.
+#
+  "failmaster" = "webmaster";
+
+
+# Accounts alias: - too much shit going to committee -mark
+#
+  "accounts" = "elected-admins, treasurer, chair";
+
+# Redbrick encyclopedia sybmissions/queries.
+#
+# wishkah gave webgroup encylopedia, on conditions he
+# be included in mails about it - <bubble>
+#
+  "encyclopedia" = "wishkah";
+
+# c-hey maintainters alias.
+#
+  "c-hey" = "pooka, colmmacc, bobb";
+
+# DNS.
+#
+# DrJolt Fri Feb 27 12:16:17 GMT 1998
+#
+  "dns" = "committee";
+
+# cancel-announce
+#
+# Cthulhu Thu Jan 27 01:00:00 GMT 2000
+#
+  "cancel-announce" = "bobb";
+
+
+#---------------#
+# Miscellaneous #
+#---------------#
+
+  "wimax" = "johan";
+
+# Alias for STOCS to go with Web Page URL. (Added cthulhu)
+#
+  "sillicon" = "stocs";
+  "spamtastic" = "bubble";
+
+# an anonymous news gateway for redbrick.sex
+#redbrick.sex:           "|/local/bin/gateway"
+
+  "su-webgroup" = "phil, arioch, p, esoteric";
+
+# The Sensei Go Club
+  "senseigoclub" = "pooka, belial, plop+go";
+
+# commonly used mailing-lists
+  "committee" = "committee@lists.${tld}";
+  "rb-admins" = "rb-admins@lists.${tld}";
+  "elected-admins" = "elected-admins@lists.${tld}";
+  "helpdesk" = "helpdesk@lists.${tld}";
+  "webmaster" = "webmaster@lists.${tld}";
+  "admin-discuss" = "admin-discuss@lists.${tld}";
+  "trainee-admins" = "trainee-admins@lists.${tld}";
+
+  "blog" = "atlas";
+  "skyhawk" = "declan";
+#
+# Mailing list to news aliases.
+#
+# $Id: lists_aliases,v 1.5 2003/11/13 11:05:47 tuama Exp $
+#
+
+#
+# NOTES
+# =====
+# - Run 'make exim_aliases' after editing. If no errors found then check it back into
+#   RCS which also implies -> this file is under RCS!
+#
+
+  "redbrick-greendaybugtraq" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.bugtraq\"";
+  "redbrick-ilug" = "\"|/srv/bin/m2n/mail2nntp.pl lists.ilug\"";
+#redbrick-ilug: "receive"
+  "gmail-invites" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl redbrick.gmail-invites\"";
+  "redbrick-debian-security" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.debian-security\"";
+  "redbrick-apache" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.apache\"";
+  "redbrick-exim" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.exim\"";
+  "redbrick-php" = "\"ryaner\"";
+#
+# Personal (non-committee) aliases.
+#
+# $Id: personal_aliases,v 1.60 2016/10/13 11:33:51 koffee Exp $
+#
+
+#
+# NOTES
+# =====
+# - Run 'make exim_aliases' after editing.
+# - File is under RCS.
+#
+
+# <drjolt> Tue Sep 26 22:15:53 IST 2000
+  "tom.doyle" = "greenday";
+  "hairforceone" = "greenday";
+  "david.craig" = "vexation";
+  "dave.murphy" = "drjolt";
+  "david.murphy" = "drjolt";
+  "s.maher" = "snoopie";
+  "Robert.Carew" = "rob";
+  "diablo" = "fergus";
+  "antarbh" = "supres";
+  "colin.whittaker" = "grimnar";
+  "meaigs" = "afrodite";
+  "Margaret.McGaley" = "afrodite";
+  "Kevin.Cannon" = "p";
+  "raz" = "ivor";
+  "fergusos" = "shocks";
+  "zirconia" = "zircon";
+  "eoin.mcgrath" = "bob";
+  "acahill" = "ace";
+  "Ian.Hollingsworth" = "lemming";
+  "comet" = "helmet";
+  "thomas.kelly" = "kudo";
+  "debug" = "ubiquity";
+  "webradio" = "kudo, singer, cain, celery, thayl";
+  "red_giant" = "redgiant";
+  "dong" = "tunney";
+  "donal.mulligan" = "thor";
+  "donal" = "thor";
+  "Tanya.Reilly" = "toaster";
+  "mark.dunne" = "pixies";
+  "cathal.thorne" = "bodie";
+  "lickylips" = "lickylip";
+  "youknowwho" = "lickylip";
+  "john.canavan" = "tibor";
+  "john" = "tibor";
+  "john.lyons" = "homerj";
+  "brian.scanlan" = "singer";
+  "caroline.sheedy" = "bootie";
+  "jon.lundberg" = "spock";
+  "jonathan.lundberg" = "spock";
+  "damien.martin" = "otto";
+  "orla.mcgann" = "orly";
+  "nigel.parkes" = "elmer";
+  "eileen.gavin" = "munchkin";
+  "john.looney" = "valen";
+  "cian.synnott" = "pooka";
+  "mothlamp" = "pooka";
+#this one is for pooka's mailing list
+  "learning-journal" = "learning-journal@lists.${tld}";
+  "kachun.leung" = "plop";
+  "dermot.hanley" = "wibble";
+  "mike.mchugh" = "sandman";
+#james.raferty:		lecter
+  "james.raftery" = "lecter";
+  "aoife.mcgoveran" = "hms";
+  "andrew.lawless" = "andy";
+  "shane.ohuid" = "wishkah";
+  "daire.mckenna" = "fatwa";
+  "john.barker" = "barkerj";
+  "sean.cullen" = "hyper";
+  "paraic.oceallaigh" = "swipe";
+  "micheal.mchugh" = "sandman";
+  "fergus.donohue" = "fergus";
+  "barry.oneill" = "bubble";
+  "aoife.cahill" = "ace";
+  "sheila.pollard" = "sheila";
+  "robert.crosbie" = "bobb";
+  "bobb-spam" = "bobb";
+  "bobb-spam0" = "bobb";
+  "bobb-spam1" = "bobb";
+  "bobb-spam2" = "bobb";
+  "bobb-spam3" = "bobb";
+  "bobb-spam4" = "bobb";
+  "bobb-spam5" = "bobb";
+  "bobb-spam6" = "bobb";
+  "bobb-spam7" = "bobb";
+  "bobb-spam8" = "bobb";
+  "bobb-spam9" = "bobb";
+  "adam.kelly" = "cthulhu";
+  "justin.moran" = "cain";
+  "cecily.murray" = "celery";
+  "karl.podesta" = "kpodesta";
+  "ronan.ryan" = "ledge";
+  "johnny" = "jonny";
+  "andrew.phillips" = "jesus";
+  "hoi.chau.wong" = "whc";
+  "paddy.grant" = "floppy";
+  "patrick.grant" = "floppy";
+  "julie.kerin" = "julie";
+  "iddqd" = "macbain";
+  "michael.mcginness" = "mikka";
+  "conor.okane" = "cokane";
+  "donal.hunt" = "redgiant";
+  "brian.bambrick" = "moridin";
+  "declan.brennan" = "wilma";
+  "grainne.walsh" = "grainy";
+  "philip.reynolds" = "phil";
+  "phil.reynolds" = "phil";
+  "mglennon" = "magluby";
+  "sigh" = "mort";
+  "mort" = "arioch";
+  "craygor" = "element";
+  "ledg" = "ledge";
+  "amanda" = "dipso";
+  "djhooker" = "wilma";
+  "dell" = "sandman";
+  "patsy" = "heavenly";
+  "raf" = "turiel";
+  "littlemisscomedy" = "lmc";
+  "samresh" = "doomgod";
+  "conor.coyle" = "squaw";
+  "kevinbrennan" = "zircon";
+  "alanthecat" = "alantc";
+  "colm.maccarthaigh" = "colmmacc";
+  "pizzateam" = "sonic";
+  "holyspambatman" = "sonic";
+  "david.johnston" = "emperor";
+  "dermot.duffy" = "dizer";
+  "dizerspam" = "dizer";
+  "eoin.campbell" = "cambo";
+  "neil.walsh" = "marvin";
+  "barry" = "bubble";
+  "anthony.moyles" = "huey";
+  "mclarke" = "prolix";
+  "mclark" = "prolix";
+  "mark_campbell" = "mark";
+  "mark.campbell" = "mark";
+  "mcampbell" = "mark";
+  "campbellm" = "mark";
+  "pronane" = "kaos";
+  "shane_tallon" = "del_boy";
+  "wesley.gorman" = "badboy";
+  "ciaran.kenny" = "goratrix";
+  "trevor.johnston" = "trevj";
+  "sinead.mcgivney" = "neady";
+  "enda_dowling" = "deano";
+  "david.concannon" = "shimoda";
+  "gary_ludgate" = "dice";
+  "martin.clarke" = "prolix";
+  "cambo1982" = "cambo";
+  "jonathan.walsh" = "melmoth";
+  "ann.byrne" = "halfpint";
+  "martin.harte" = "tuama";
+  "lee.cash" = "brodie";
+  "declan.oneill" = "dec";
+  "keith.mcdonnell" = "bkeeper";
+  "john.ruddy" = "phase";
+  "peter.sinnott" = "link";
+  "michael.dowling" = "mickeyd";
+  "mickeydspam" = "mickeyd";
+  "eoghan" = "atlas";
+  "dru" = "drusilla";
+  "wavehunt" = "johan";
+  "stephen.ryan37" = "ryaner";
+  "natashamaher" = "7of9";
+  "huskerdu" = "phl";
+  "credak" = "creadak";
+  "craig.gavagan" = "creadak";
+  "joeh762" = "kuze";
+  "macattac" = "mak";
+  "failho" = "carri";
+  "bunny" = "bunbun";
+# This burd wanted this alias. She's a friend of mine (singer).
+# She used to be these addresses. Get rid of them and you're
+# all dead. Yes, even you, son of drjolt in the year 2525.
+  "zorro" = "\"Aisling.NiCheallachain@irishlife.ie\"";
+  "aisfc" = "\"Aisling.NiCheallachain@irishlife.ie\"";
+  "assassins" = "art_wolf";
+  "sarunas" = "svan";
+  "sarunas.v" = "svan";
+  "sarunas.vancevicius" = "svan";
+  "eoghan.gaffney" = "atlas";
+  "carbonkid" = "gaara";
+  "waf" = "dregin";
+  "surfnsail" = "sailing";
+  "andrew.martin" = "werdz";
+  "mieows" = "angelkat";
+  "cocowtf" = "cocao";
+  "patrickswayze" = "goldfish";
+  "wolfhead" = "drg";
+  "david.lynam" = "coconut";
+  "cian.brennan" = "lil_cain";
+  "cian" = "lil_cain";
+  "biggestpenis" = "lil_cain";
+  "eoghan.cotter" = "johan";
+  "austin.halpin" = "haus";
+  "shane.stacey" = "isaac702";
+  "fruitcake" = "fructus";
+  "fruitcaek" = "fructus";
+  "lotta.mikkonen" = "attol";
+  "diarmaid.mcmanus" = "elephant";
+  "caroline.fuery" = "carri";
+  "damien.rhatigan" = "dano";
+  "jennifer.flynn" = "jennyf";
+  "michael.odowd" = "nanaki";
+  "microman" = "m1cr0man";
+
+# guess which one is the correct one
+  "kat.farrell" = "angelkat";
+  "kat.farrel" = "angelkat";
+  "kat.farell" = "angelkat";
+  "kat.farel" = "angelkat";
+#for sonic
+  "alan.walsh" = "sonic";
+  "alwalsh" = "sonic";
+  "alanwalsh" = "sonic";
+  "sonicthehedgehog" = "sonic";
+# aliases for receive :)
+  "andrew.harford" = "receive";
+  "andrew.j.harford" = "receive";
+  "andy.harford" = "receive";
+  "winchair" = "angelkat";
+  "winkat" = "angelkat";
+  "starbuck" = "receive";
+  "latvia" = "\"latvia@lists.${tld}\"";
+# people spell bad
+  "recieve" = "receive";
+  "andrew.hartford" = "receive";
+  "lotta" = "attol";
+  "powertax" = "pwrtaxi";
+#games
+  "trainisgay" = "gamessoc";
+  "gamestocs" = "gamessoc";
+  "games1" = "gamessoc";
+  "games2" = "gamessoc";
+#gamessoc
+  "gamessoc1" = "gamessoc";
+  "gamessoc2" = "gamessoc";
+  "gamessoc3" = "gamessoc";
+  "gamessoc4" = "gamessoc";
+  "gamessoc5" = "gamessoc";
+  "gamessoc6" = "gamessoc";
+  "gamessoc7" = "gamessoc";
+  "gamessoc8" = "gamessoc";
+  "gamessoc9" = "gamessoc";
+  "gamessoc10" = "gamessoc";
+  "gamessoc11" = "gamessoc";
+  "gamessoc12" = "gamessoc";
+  "gamessoc13" = "gamessoc";
+#commonroom list
+  "commonroom" = "\"commonroom@lists.${tld}\"";
+
+  "jennyf" = "ribbons";
+  "niall.gaffney" = "gamma";
+  "richard.walsh" = "koffee";
+  "richie" = "koffee";
+  "vadim" = "vadimck";
+  "lorcan.boyle" = "zergless";
+  "robert.devereux" = "kylar";
+  "christopher.boyle" = "greyman";
+  "cboyle" = "greyman";
+  "renting" = "\"rental@lists.${tld}\"";
+  "cliodhna.harrison" = "thegirl";
+#
+# Mail aliasii for disusered people :) Their redbrick mail
+# should be redirected to their alternate address.
+#
+# $Id: user_disusered_aliases,v 1.52 2003/11/13 10:56:25 tuama Exp $
+#
+# NOTES
+# =====
+# - Please don't edit this file manually, use the disuser functionality
+#   in useradm.
+# - Run 'make exim_aliases' after editing.
+# - File is under RCS.
+# - Format is old_username: new_username
+#
+# Removed this cause userdel didnt remove it
+#noid:			/var/mail/noid
+#
+# Renamed/changed username aliases.
+#
+# $Id: user_rename_aliases,v 1.17 2013/07/11 19:22:20 fun Exp $
+#
+
+#
+# NOTES
+# =====
+# - Run 'make exim_aliases' after editing.
+# - File is under RCS.
+# - Should really have a database to do this...
+# - Format is old_username: new_username
+# - An irate pixies says: "shoot *any* of them who ask again"
+#
+
+  "safrole" = "saf";
+  "jonny" = "banjo";
+  "xmeabhx" = "timelady";
+  "jamesreilly" = "fun";
+  "snowda" = "fordy";
+  "funtrain" = "admins";
+  "ladmins" = "admins";
+  "tron" = "jammy";
+  "amadan" = "marvin";
+  "mike_d" = "marvin";
+  "loky" = "chikatee";
+  "scunni" = "jericho";
+  "the_rock" = "jericho";
+  "iruane" = "stark";
+  "aurora" = "smf";
+  "smithers" = "manuel";
+  "jonnyb" = "nedd";
+  "wwallace" = "epic";
+  "lizard" = "creech";
+  "lep" = "phat";
+  "crispy" = "chris";
+  "account" = "afsoc";
+  "odie" = "me";
+  "hriding" = "equest";
+  "equestrian" = "equest";
+
+  "economosoc" = "econosoc";
+
+# now a spamtrap - colmmacc
+  "sarahb" = "/dev/null";
+  "audi_58" = "AUDI_S8";
+  "c_clay" = "fallen";
+  "rcummi" = "4aces";
+  "imelda" = "fruity";
+  "mulinho" = "mullins";
+  "sully1" = "sully";
+  "robert" = "gandalf";
+  "d_omall" = "domall";
+  "dhunt" = "zoro";
+  "seth" = "stranger";
+  "jolt-9" = "chalk";
+  "gee_sus" = "gee";
+  "jruddy" = "phase";
+  "lynchman" = "mloc";
+  "brianh" = "alantc";
+  "sutty" = "yosarian";
+  "ryanks" = "rhino";
+  "aliastom" = "ayatolah";
+  "osprey" = "pariah";
+  "jbolger" = "x";
+  "joey_p" = "mrs_girl";
+  "vigdis" = "tom";
+  "dimitri" = "grover";
+  "oasis" = "geezer";
+  "games" = "gamessoc";
+  "smeghead" = "jeebers";
+  "piesoc" = "matsoc";
+  "cherub" = "crumbs";
+  "dme3" = "dme4";
+  "garyod2" = "gary";
+  "haus17" = "haus";
+  "nadned" = "damnson";
+}

--- a/services/postfix/aliases.nix
+++ b/services/postfix/aliases.nix
@@ -1,26 +1,16 @@
-{tld}:
-{
-#
-# System, committee and important email aliases.
-#
-# $Id: aliases,v 1.18 2015/11/18 19:16:50 koffee Exp koffee $
-#
+{tld}: {
+  # System, committee and important email aliases.
+  #
+  # NOTES
+  # =====
+  # - For committee position aliases during the changeover period, list the
+  #   outgoing person(s) first followed by the incoming person(s).
 
-#
-# NOTES
-# =====
-# - For committee position aliases during the changeover period, list the
-#   outgoing person(s) first followed by the incoming person(s).
-#
+  #-----------------#
+  # SYSTEM ACCOUNTS #
+  #-----------------#
 
-
-#-----------------#
-# SYSTEM ACCOUNTS #
-#-----------------#
-
-
-# Redirections for system and pseudo accounts.
-#
+  # Redirections for system and pseudo accounts.
   "MAILER-DAEMON" = "postmaster";
   "postmaster" = "root";
   "bin" = "root";
@@ -45,201 +35,122 @@
   "_nagios" = "root";
   "ossec" = "root";
 
-# Mailman
-#
+  # Mailman
   "mailman" = "root";
   "mailman-owner" = "mailman";
   "mailman-request" = "mailman";
   "mailman-bounces" = "mailman";
   "mailman-admin" = "mailman";
 
-# Where root mail goes. VERY IMPORTANT!
-#
+  # Where root mail goes. VERY IMPORTANT!
   "root" = "rb-admins";
 
-#bit-bucket:		/dev/null
-#dev-null:		bit-bucket
+  #----------------#
+  # Administrators #
+  #----------------#
 
-
-#----------------#
-# Administrators #
-#----------------#
-
-# Who wants to get system reports, cron job output etc.
-#
+  # Who wants to get system reports, cron job output etc.
   "system-reports" = "rb-admins";
   "audit_warn" = "system-reports";
 
-# Offical way to contact admins for requests.
-#
+  # Offical way to contact admins for requests.
   "admin-request" = "rb-admins, ticket";
   "elected-admin" = "elected-admins";
 
-# Where mail addressed to generic 'admins' goes.
-#
+  # Where mail addressed to generic 'admins' goes.
   "admin" = "admin-request";
   "admins" = "admin-request";
 
-# DCU admin list.
-#
-# <plop>: Thu May 28 11:07:05 BST 1998
-#
+  # DCU admin list.
+  #
+  # <plop>: Thu May 28 11:07:05 BST 1998
   "dcu-admin-list" = "rb-admins, sysops@dcu.ie, mcgorman@compapp.dcu.ie";
 
+  # Admin Mailing lists
+  "rb-admins" = "rb-admins@lists.${tld}";
+  "elected-admins" = "elected-admins@lists.${tld}";
+  "admin-discuss" = "admin-discuss@lists.${tld}";
+  "trainee-admins" = "trainee-admins@lists.${tld}";
 
-#-------------#
-# Web related #
-#-------------#
+  #-------------#
+  # Web related #
+  #-------------#
 
-# webmaster is now a mailman list
-
+  # webmaster is a mailman list
   "httpd" = "webmaster";
   "www" = "webmaster";
+  "webmaster" = "webmaster@lists.${tld}";
 
+  #---------------------#
+  # Committee & Society #
+  #---------------------#
 
-#---------------------#
-# Committee & Society #
-#---------------------#
-
-
-# "The Founders" (TM)
-#
+  # "The Founders" (TM)
   "founders" = "drjolt, wibble, sandman, fergus, swipe, hyper";
 
-# Committee is now a mailing list (handled by mailman)
-#
+  # Committee is a mailing list (handled by mailman)
+  "committee" = "committee@lists.${tld}";
 
-# HELP! requests.
-#
+  # HELP! requests.
   "help" = "helpdesk";
   "support" = "helpdesk";
   "help-request" = "helpdesk";
   "helpdesk-request" = "helpdesk";
-  "faildesk" = "helpdesk";
-  "thosecunts" = "helpdesk";
+  "helpdesk" = "helpdesk@lists.${tld}";
 
-# Chairperson alias.
-#
+  # Chairperson alias.
   "chairperson" = "chair";
-  "failchair" = "chair";
 
-# Treasurer alias.
-#
+  # Treasurer alias.
   "treasurer" = "treasure";
 
-# Secretary alias.
-#
+  # Secretary alias.
   "secretary" = "sec";
-  "failsec" = "sec";
 
-# PRO alias.
-#
-  "profail" = "pro";
-
-# Ents alias.
-#
+  # Events alias.
   "ents" = "events";
-  "failents" = "events";
   "birthday" = "events";
 
-# Webmaster aliass.
-#
-  "failmaster" = "webmaster";
-
-
-# Accounts alias: - too much shit going to committee -mark
-#
+  # Accounts alias:
   "accounts" = "elected-admins, treasurer, chair";
 
-# Redbrick encyclopedia sybmissions/queries.
-#
-# wishkah gave webgroup encylopedia, on conditions he
-# be included in mails about it - <bubble>
-#
+  # Redbrick encyclopedia sybmissions/queries.
+  #
+  # wishkah gave webgroup encylopedia, on conditions he
+  # be included in mails about it - <bubble>
+  #
   "encyclopedia" = "wishkah";
 
-# c-hey maintainters alias.
-#
+  # c-hey maintainters alias.
   "c-hey" = "pooka, colmmacc, bobb";
 
-# DNS.
-#
-# DrJolt Fri Feb 27 12:16:17 GMT 1998
-#
+  # DNS.
   "dns" = "committee";
 
-# cancel-announce
-#
-# Cthulhu Thu Jan 27 01:00:00 GMT 2000
-#
+  # cancel-announce
+  # Cthulhu Thu Jan 27 01:00:00 GMT 2000
   "cancel-announce" = "bobb";
 
+  #---------------#
+  # Miscellaneous #
+  #---------------#
 
-#---------------#
-# Miscellaneous #
-#---------------#
+  # Mailing List aliases
+  "commonroom" = "\"commonroom@lists.${tld}\"";
+  "latvia" = "\"latvia@lists.${tld}\"";
+  "renting" = "\"rental@lists.${tld}\"";
+  # this one is for pooka's mailing list
+  "learning-journal" = "learning-journal@lists.${tld}";
 
+  # User aliases
   "wimax" = "johan";
-
-# Alias for STOCS to go with Web Page URL. (Added cthulhu)
-#
+  # Alias for STOCS to go with Web Page URL. (Added cthulhu)
   "sillicon" = "stocs";
   "spamtastic" = "bubble";
-
-# an anonymous news gateway for redbrick.sex
-#redbrick.sex:           "|/local/bin/gateway"
-
   "su-webgroup" = "phil, arioch, p, esoteric";
-
-# The Sensei Go Club
   "senseigoclub" = "pooka, belial, plop+go";
-
-# commonly used mailing-lists
-  "committee" = "committee@lists.${tld}";
-  "rb-admins" = "rb-admins@lists.${tld}";
-  "elected-admins" = "elected-admins@lists.${tld}";
-  "helpdesk" = "helpdesk@lists.${tld}";
-  "webmaster" = "webmaster@lists.${tld}";
-  "admin-discuss" = "admin-discuss@lists.${tld}";
-  "trainee-admins" = "trainee-admins@lists.${tld}";
-
   "blog" = "atlas";
   "skyhawk" = "declan";
-#
-# Mailing list to news aliases.
-#
-# $Id: lists_aliases,v 1.5 2003/11/13 11:05:47 tuama Exp $
-#
-
-#
-# NOTES
-# =====
-# - Run 'make exim_aliases' after editing. If no errors found then check it back into
-#   RCS which also implies -> this file is under RCS!
-#
-
-  "redbrick-greendaybugtraq" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.bugtraq\"";
-  "redbrick-ilug" = "\"|/srv/bin/m2n/mail2nntp.pl lists.ilug\"";
-#redbrick-ilug: "receive"
-  "gmail-invites" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl redbrick.gmail-invites\"";
-  "redbrick-debian-security" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.debian-security\"";
-  "redbrick-apache" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.apache\"";
-  "redbrick-exim" = "\"|/srv/admin/scripts/m2n/mail2nntp.pl lists.exim\"";
-  "redbrick-php" = "\"ryaner\"";
-#
-# Personal (non-committee) aliases.
-#
-# $Id: personal_aliases,v 1.60 2016/10/13 11:33:51 koffee Exp $
-#
-
-#
-# NOTES
-# =====
-# - Run 'make exim_aliases' after editing.
-# - File is under RCS.
-#
-
-# <drjolt> Tue Sep 26 22:15:53 IST 2000
   "tom.doyle" = "greenday";
   "hairforceone" = "greenday";
   "david.craig" = "vexation";
@@ -286,12 +197,10 @@
   "john.looney" = "valen";
   "cian.synnott" = "pooka";
   "mothlamp" = "pooka";
-#this one is for pooka's mailing list
-  "learning-journal" = "learning-journal@lists.${tld}";
   "kachun.leung" = "plop";
   "dermot.hanley" = "wibble";
   "mike.mchugh" = "sandman";
-#james.raferty:		lecter
+  "james.raferty" = "lecter";
   "james.raftery" = "lecter";
   "aoife.mcgoveran" = "hms";
   "andrew.lawless" = "andy";
@@ -401,9 +310,10 @@
   "macattac" = "mak";
   "failho" = "carri";
   "bunny" = "bunbun";
-# This burd wanted this alias. She's a friend of mine (singer).
-# She used to be these addresses. Get rid of them and you're
-# all dead. Yes, even you, son of drjolt in the year 2525.
+  # This burd wanted this alias. She's a friend of mine (singer).
+  # She used to be these addresses. Get rid of them and you're
+  # all dead. Yes, even you, son of drjolt in the year 2525.
+  # ok boomer - m1cr0man, 2020
   "zorro" = "\"Aisling.NiCheallachain@irishlife.ie\"";
   "aisfc" = "\"Aisling.NiCheallachain@irishlife.ie\"";
   "assassins" = "art_wolf";
@@ -435,36 +345,33 @@
   "jennifer.flynn" = "jennyf";
   "michael.odowd" = "nanaki";
   "microman" = "m1cr0man";
-
-# guess which one is the correct one
+  "cian.butler" = "butlerx";
+  # guess which one is the correct one
   "kat.farrell" = "angelkat";
   "kat.farrel" = "angelkat";
   "kat.farell" = "angelkat";
   "kat.farel" = "angelkat";
-#for sonic
+  #for sonic
   "alan.walsh" = "sonic";
   "alwalsh" = "sonic";
   "alanwalsh" = "sonic";
   "sonicthehedgehog" = "sonic";
-# aliases for receive :)
+  # aliases for receive :)
   "andrew.harford" = "receive";
   "andrew.j.harford" = "receive";
   "andy.harford" = "receive";
   "winchair" = "angelkat";
   "winkat" = "angelkat";
   "starbuck" = "receive";
-  "latvia" = "\"latvia@lists.${tld}\"";
-# people spell bad
+  # people spell bad
   "recieve" = "receive";
   "andrew.hartford" = "receive";
   "lotta" = "attol";
   "powertax" = "pwrtaxi";
-#games
-  "trainisgay" = "gamessoc";
+
   "gamestocs" = "gamessoc";
   "games1" = "gamessoc";
   "games2" = "gamessoc";
-#gamessoc
   "gamessoc1" = "gamessoc";
   "gamessoc2" = "gamessoc";
   "gamessoc3" = "gamessoc";
@@ -478,8 +385,6 @@
   "gamessoc11" = "gamessoc";
   "gamessoc12" = "gamessoc";
   "gamessoc13" = "gamessoc";
-#commonroom list
-  "commonroom" = "\"commonroom@lists.${tld}\"";
 
   "jennyf" = "ribbons";
   "niall.gaffney" = "gamma";
@@ -490,40 +395,7 @@
   "robert.devereux" = "kylar";
   "christopher.boyle" = "greyman";
   "cboyle" = "greyman";
-  "renting" = "\"rental@lists.${tld}\"";
   "cliodhna.harrison" = "thegirl";
-#
-# Mail aliasii for disusered people :) Their redbrick mail
-# should be redirected to their alternate address.
-#
-# $Id: user_disusered_aliases,v 1.52 2003/11/13 10:56:25 tuama Exp $
-#
-# NOTES
-# =====
-# - Please don't edit this file manually, use the disuser functionality
-#   in useradm.
-# - Run 'make exim_aliases' after editing.
-# - File is under RCS.
-# - Format is old_username: new_username
-#
-# Removed this cause userdel didnt remove it
-#noid:			/var/mail/noid
-#
-# Renamed/changed username aliases.
-#
-# $Id: user_rename_aliases,v 1.17 2013/07/11 19:22:20 fun Exp $
-#
-
-#
-# NOTES
-# =====
-# - Run 'make exim_aliases' after editing.
-# - File is under RCS.
-# - Should really have a database to do this...
-# - Format is old_username: new_username
-# - An irate pixies says: "shoot *any* of them who ask again"
-#
-
   "safrole" = "saf";
   "jonny" = "banjo";
   "xmeabhx" = "timelady";
@@ -552,7 +424,7 @@
 
   "economosoc" = "econosoc";
 
-# now a spamtrap - colmmacc
+  # now a spamtrap - colmmacc
   "sarahb" = "/dev/null";
   "audi_58" = "AUDI_S8";
   "c_clay" = "fallen";

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -21,7 +21,7 @@ let
   ldapSenderMap = pkgs.writeText "postfix-sender-maps" (ldapCommon + ''
     query_filter = (&(objectClass=posixAccount)(uid=%u))
     result_attribute = uid
-    result_format = %s@${tld}
+    result_format = %s
   '');
 
   # Addresses we reject mail from over port 25

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -6,7 +6,7 @@ let
   common = import ../../common/variables.nix;
 
   aliases = import ./aliases.nix { inherit tld; };
-  aliasesFile = pkgs.writeText "postfix-aliases" (lib.mapAttrs' (k: v: "${k}: ${v}"));
+  aliasesFile = pkgs.writeText "postfix-aliases" (builtins.concatStringsSep "\n" (lib.mapAttrsToList (k: v: "${k}: ${v}") aliases));
 
   ldapCommon = ''
     server_host = ldap://${common.ldapHost}/

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -1,9 +1,12 @@
 # Requires rspamadm dkim_keygen -k /var/secrets/${tld}.$(hostname).dkim.key -b 2048 -s $(hostname) -d ${tld}
 # chown rspamd:root chmod 400
-{config, pkgs, ...}:
+{config, pkgs, lib, ...}:
 let
   tld = config.redbrick.tld;
   common = import ../../common/variables.nix;
+
+  aliases = import ./aliases.nix { inherit tld; };
+  aliasesFile = pkgs.writeText "postfix-aliases" (lib.mapAttrs' (k: v: "${k}: ${v}"));
 
   ldapCommon = ''
     server_host = ldap://${common.ldapHost}/
@@ -105,6 +108,9 @@ in {
     mapFiles.sender_whitelist = sender_whitelist;
     mapFiles.sender_blacklist = sender_blacklist;
     mapFiles.unauth_ip_blacklist = unauth_ip_blacklist;
+
+    # Aliases
+    aliasFiles.redbrick = aliasesFile;
 
     config = {
       # IP address used by postfix to send outgoing mail. You only need this if

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -110,7 +110,7 @@ in {
     mapFiles.unauth_ip_blacklist = unauth_ip_blacklist;
 
     # Aliases
-    aliasFiles.redbrick = aliasesFile;
+    aliasFiles.redbrick_aliases = aliasesFile;
 
     config = {
       # IP address used by postfix to send outgoing mail. You only need this if
@@ -119,11 +119,6 @@ in {
       smtp_bind_address = "192.168.0.135";
       # http://www.postfix.org/BASIC_CONFIGURATION_README.html#proxy_interfaces
       proxy_interfaces = "136.206.15.5";
-
-      #virtual_mailbox_domains = tld;
-      #virtual_mailbox_maps = "hash:/var/lib/postfix/aliases";
-      #virtual_alias_maps = "ldap:" ++ ./ldap-virtual-alias-maps.cf;
-      # alias_maps = "hash:/etc/aliases, ldap:";
 
       # Generate own DHParams
       smtpd_tls_dh512_param_file = config.security.dhparams.params.smtpd_512.path;
@@ -143,6 +138,9 @@ in {
       # For the sake of possible NixOS overrides,
       # set the default local_recipient_maps explicitly
       local_recipient_maps = [ "proxy:unix:passwd.byname" ];
+
+      # Written to /etc/postfix by the nix config
+      alias_maps = [ "hash:/etc/postfix/redbrick_aliases" ];
 
       # Configure postsrsd so that forwarded mail is "remailed" with a safe from address
       sender_canonical_maps = "tcp:127.0.0.1:${builtins.toString config.services.postsrsd.forwardPort}";

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -61,8 +61,8 @@ in {
 
   # Ensure postsrsd is started before postfix
   systemd.services.postfix = {
-    requires = [ "postsrsd.service" ];
-    after = [ "postsrsd.service" ];
+    requires = [ "postsrsd.service" "redis.service" "rspamd.service" ];
+    after = [ "postsrsd.service" "redis.service" "rspamd.service" ];
   };
 
   networking.firewall.allowedTCPPorts = [ 25 587 ];
@@ -133,6 +133,10 @@ in {
       # deliver mail for virtual users to Dovecot's TCP socket
       # http://www.postfix.org/lmtp.8.html
       mailbox_transport = "lmtp:inet:${common.dovecotHost}:${builtins.toString common.dovecotLmtpPort}";
+
+      # For the sake of possible NixOS overrides,
+      # set the default local_recipient_maps explicitly
+      local_recipient_maps = [ "proxy:unix:passwd.byname" ];
 
       # Configure postsrsd so that forwarded mail is "remailed" with a safe from address
       sender_canonical_maps = "tcp:127.0.0.1:${builtins.toString config.services.postsrsd.forwardPort}";

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -24,6 +24,7 @@ let
   ];
 in {
   imports = [
+    ./mailman.nix
     ./postsrsd.nix
   ];
 
@@ -34,6 +35,10 @@ in {
   };
 
   networking.firewall.allowedTCPPorts = [ 25 587 ];
+
+  # Since the TLD cert is a wildcard, this allows us to use TLS
+  # over localhost and authenticate correctly. Used in mailman
+  networking.hosts."127.0.0.1" = [ "localmail.${tld}" ];
 
   security.dhparams.enable = true;
   security.dhparams.params.smtpd_512.bits = 512;

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -209,9 +209,10 @@ in {
         "reject_sender_login_mismatch" "permit_sasl_authenticated"
         # Prevent anyone from @${tld} sending mail unauthenticated
         "check_sender_access hash:/var/lib/postfix/conf/sender_blacklist"
-        "reject_unlisted_sender" "permit_mynetworks" "reject_unauth_pipelining"
+        "reject_unlisted_sender" "reject_unauth_pipelining"
+        # reject_unknown_sender_domain stops people spoofing addresses internally
         "reject_non_fqdn_sender" "reject_unknown_sender_domain"
-        "warn_if_reject" "reject_unverified_sender"
+        "permit_mynetworks" "warn_if_reject" "reject_unverified_sender"
       ]);
       smtpd_recipient_restrictions = builtins.concatStringsSep ", " (commonRestrictions ++ [
         "reject_non_fqdn_recipient" "reject_unknown_recipient_domain"

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -119,9 +119,14 @@ in {
       # IP address used by postfix to send outgoing mail. You only need this if
       # your machine has multiple IP addresses - set it to your MX address to
       # satisfy your SPF record.
-      smtp_bind_address = "192.168.0.135";
+      smtp_bind_address = "192.168.0.158";
       # http://www.postfix.org/BASIC_CONFIGURATION_README.html#proxy_interfaces
-      proxy_interfaces = "136.206.15.5";
+      proxy_interfaces = "136.206.15.3";
+
+      # Some bad clients...like MAILMAN... forget to add some important headers
+      # In particular I saw mailman forget Message-ID. This setting permits postfix
+      # to fix them
+      local_header_rewrite_clients = "permit_sasl_authenticated";
 
       # Generate own DHParams
       smtpd_tls_dh512_param_file = config.security.dhparams.params.smtpd_512.path;
@@ -132,11 +137,11 @@ in {
       # https://wiki.dovecot.org/HowTo/PostfixAndDovecotSASL
       smtpd_sasl_auth_enable = true;
       smtpd_sasl_type = "dovecot";
-      smtpd_sasl_path = "inet:${common.dovecotHost}:${builtins.toString common.dovecotSaslPort}";
+      smtpd_sasl_path = "unix:/var/run/dovecot2_sasl.sock";
 
-      # deliver mail for virtual users to Dovecot's TCP socket
+      # Deliver mail for all users to Dovecot's LMTP socket
       # http://www.postfix.org/lmtp.8.html
-      mailbox_transport = "lmtp:inet:${common.dovecotHost}:${builtins.toString common.dovecotLmtpPort}";
+      mailbox_transport = "lmtp:unix:/var/run/dovecot2_lmtp.sock";
 
       # For the sake of possible NixOS overrides,
       # set the default local_recipient_maps explicitly

--- a/services/postfix/exim2nix.py
+++ b/services/postfix/exim2nix.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Python 3.6+
+# Converts exim aliases text file to Nix
+# Usage: cat exim_aliases.txt | ./exim2nix.py > aliases.nix
+import sys
+
+print('{')
+for l in sys.stdin:
+    if '#' not in l and ':' in l:
+        try:
+            alias, to = l.strip().split(':')
+        except:
+            print("Broken line", l.strip())
+            continue
+        alias = alias.strip()
+        to = to.strip().replace('"', r'\"')
+        print(f"  \"{alias}\" = \"{to}\";")
+    else:
+        print(l.strip())
+print('}')

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -9,7 +9,7 @@ let
   postgresHost = "127.0.0.1";
 
   # Mailman needs access to hyperkitty, which is on the same host
-  hyperkittyLocal = "lists.local";
+  hyperkittyLocal = "localmail.${tld}";
 in {
   services.mailman = {
     enable = true;
@@ -110,7 +110,7 @@ in {
 
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
     EMAIL_HOST = 'localmail.${tld}'
-    EMAIL_PORT = 25
+    EMAIL_PORT = 587
     EMAIL_USE_TLS = True
     EMAIL_HOST_USER = secrets['email_user']
     EMAIL_HOST_PASSWORD = secrets['email_password']
@@ -122,8 +122,6 @@ in {
     config.transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
     config.local_recipient_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
   };
-
-  networking.hosts."127.0.0.1" = [ hyperkittyLocal ];
 
   networking.firewall.allowedTCPPorts = [ 80 ];
 }

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -1,0 +1,129 @@
+# Manual steps post-deploy:
+# cd /var/lib/mailman && sudo -u mailman mailman aliases && sysemctl restart postfix
+{pkgs, config, lib, ...}:
+let
+  common = import ../../common/variables.nix;
+
+  tld = config.redbrick.tld;
+  secretsFile = "/var/secrets/mailman.json";
+  postgresHost = "127.0.0.1";
+
+  # Mailman needs access to hyperkitty, which is on the same host
+  hyperkittyLocal = "lists.local";
+in {
+  services.mailman = {
+    enable = true;
+    siteOwner = "postmaster@${tld}";
+    webHosts = [ "lists.${tld}" ];
+    hyperkitty = {
+      enable = true;
+      baseUrl = "http://${hyperkittyLocal}/hyperkitty/";
+    };
+  };
+
+  # Our ldap has combined first name + last name (cn), and no email field
+  # If there's ever a Django dev looking at this and sees a better way to do it,
+  # PLEASE DO IT
+  environment.etc."mailman3/rbapp/__init__.py".text = ''
+    __version__ = '1.0.0'
+    default_app_config = 'rbapp.apps.RBAppConfig'
+  '';
+  environment.etc."mailman3/rbapp/signals.py".text = ''
+    from django_auth_ldap.backend import populate_user
+    from django.dispatch import receiver
+
+    @receiver(populate_user)
+    def on_populate_user(sender, **kwargs):
+        """Process population of a user."""
+        user = kwargs.get('user', None)
+        ldap_user = kwargs.get('ldap_user', None)
+
+        if not (user and ldap_user):
+            return
+
+        first_name, last_name = user.first_name.split()
+
+        user.email = user.username + "@${tld}"
+        user.first_name = first_name
+        user.last_name = last_name
+  '';
+  environment.etc."mailman3/rbapp/apps.py".text = ''
+    from django.apps import AppConfig
+
+    class RBAppConfig(AppConfig):
+        name = 'rbapp'
+        verbose_name = 'RB App'
+
+        def ready(self):
+            import rbapp.signals
+  '';
+  environment.etc."mailman3/settings.py".text = ''
+    # Add ldap to search path
+    # Package must be updated if main python3 version changes
+    import site
+    site.addsitedir('${pkgs.python37Packages.ldap}/lib/python3.7/site-packages')
+    site.addsitedir('${pkgs.python37Packages.pyasn1-modules}/lib/python3.7/site-packages')
+    site.addsitedir('${pkgs.python37Packages.django-auth-ldap}/lib/python3.7/site-packages')
+
+    import ldap
+    import json
+    from django_auth_ldap.config import LDAPSearch, PosixGroupType
+
+    TIME_ZONE = 'Europe/Dublin'
+
+    INSTALLED_APPS = INSTALLED_APPS + ['rbapp']
+
+    AUTHENTICATION_BACKENDS = (
+        'django_auth_ldap.backend.LDAPBackend',
+        'django.contrib.auth.backends.ModelBackend',
+    )
+
+    AUTH_LDAP_SERVER_URI = "ldap://${common.ldapHost}"
+
+    # Use the user's own credentials to bind to LDAP. Allows for reading of
+    # special fields, and no need for a mailman LDAP user
+    AUTH_LDAP_BIND_AS_AUTHENTICATING_USER = True
+    AUTH_LDAP_USER_ATTRLIST = ["*", "+"]
+    AUTH_LDAP_USER_DN_TEMPLATE = "uid=%(user)s,ou=accounts,o=redbrick"
+    AUTH_LDAP_USER_ATTR_MAP = {
+        "username": "uid",
+        "first_name": "cn",
+    }
+
+    AUTH_LDAP_GROUP_TYPE = PosixGroupType()
+    AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=accounts,o=redbrick", ldap.SCOPE_SUBTREE, "(uid=%(user)s)")
+    AUTH_LDAP_GROUP_SEARCH = LDAPSearch("ou=groups,o=redbrick", ldap.SCOPE_SUBTREE, "(objectClass=posixGroup)")
+
+    with open('${secretsFile}', 'r') as db_pass_file:
+        secrets = json.load(db_pass_file)
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': 'mailman',
+            'USER': secrets['db_user'],
+            'PASSWORD': secrets['db_password'],
+            'HOST': '${postgresHost}',
+            'PORT': '5432',
+        }
+    }
+
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = 'localmail.${tld}'
+    EMAIL_PORT = 25
+    EMAIL_USE_TLS = True
+    EMAIL_HOST_USER = secrets['email_user']
+    EMAIL_HOST_PASSWORD = secrets['email_password']
+    DEFAULT_FROM_EMAIL = 'mailman@${tld}'
+  '';
+
+  services.postfix = {
+    relayDomains = [ "hash:/var/lib/mailman/data/postfix_domains" ];
+    config.transport_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
+    config.local_recipient_maps = [ "hash:/var/lib/mailman/data/postfix_lmtp" ];
+  };
+
+  networking.hosts."127.0.0.1" = [ hyperkittyLocal ];
+
+  networking.firewall.allowedTCPPorts = [ 80 ];
+}

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -140,7 +140,7 @@ in {
     EMAIL_USE_TLS = True
     EMAIL_HOST_USER = secrets['email_user']
     EMAIL_HOST_PASSWORD = secrets['email_password']
-    DEFAULT_FROM_EMAIL = 'mailman@${tld}'
+    DEFAULT_FROM_EMAIL = 'mailmgr@${tld}'
     ACCOUNT_EMAIL_VERIFICATION = 'none'
 
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -59,9 +59,13 @@ in {
         if not (user and ldap_user):
             return
 
-        first_name, last_name = user.first_name.split()
-
         user.email = user.username + "@${tld}"
+
+        name_split = user.first_name.split()
+        if len(name_split) != 2:
+          return
+
+        first_name, last_name = name_split
         user.first_name = first_name
         user.last_name = last_name
   '';

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -20,7 +20,7 @@ in {
     webHosts = [ "lists.${tld}" ];
     hyperkitty = {
       enable = true;
-      baseUrl = "http://${hyperkittyLocal}/hyperkitty/";
+      baseUrl = "https://${hyperkittyLocal}/hyperkitty/";
     };
   };
 
@@ -92,6 +92,7 @@ in {
     from django_auth_ldap.config import LDAPSearch, PosixGroupType
 
     TIME_ZONE = 'Europe/Dublin'
+    ALLOWED_HOSTS = [ 'lists.${tld}', 'localmail.${tld}' ]
 
     # When initialising Mailman, comment this line out until you go to /admin and add a site
     # Otherwise you might get "Site matching query does not exist"
@@ -143,6 +144,7 @@ in {
     DEFAULT_FROM_EMAIL = 'mailmgr@${tld}'
     ACCOUNT_EMAIL_VERIFICATION = 'none'
 
+    AUTH_LDAP_MIRROR_GROUPS = True
     AUTH_LDAP_USER_FLAGS_BY_GROUP = {
         "is_superuser": "cn=mailadm,ou=groups,o=redbrick"
     }

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -16,7 +16,7 @@ let
 in {
   services.mailman = {
     enable = true;
-    siteOwner = "postmaster@${tld}";
+    siteOwner = "admins+mailman@${tld}";
     webHosts = [ "lists.${tld}" ];
     hyperkitty = {
       enable = true;

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -71,6 +71,10 @@ in {
 
     TIME_ZONE = 'Europe/Dublin'
 
+    # When initialising Mailman, comment this line out until you go to /admin and add a site
+    # Otherwise you might get "Site matching query does not exist"
+    SITE_ID = 2
+
     INSTALLED_APPS = INSTALLED_APPS + ['rbapp']
 
     AUTHENTICATION_BACKENDS = (
@@ -112,9 +116,11 @@ in {
     EMAIL_HOST = 'localmail.${tld}'
     EMAIL_PORT = 587
     EMAIL_USE_TLS = True
-    EMAIL_HOST_USER = secrets['email_user']
-    EMAIL_HOST_PASSWORD = secrets['email_password']
     DEFAULT_FROM_EMAIL = 'mailman@${tld}'
+
+    AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+        "is_superuser": "cn=mailadm,ou=groups,o=redbrick"
+    }
   '';
 
   services.postfix = {

--- a/services/postfix/rspamd.nix
+++ b/services/postfix/rspamd.nix
@@ -1,0 +1,94 @@
+{ config, ... }:
+let
+  milterPort = "/run/rspamd/milter.sock";
+in {
+  # Not necessary since it's in the postfix import, but just in case
+  imports = [
+    ../redis.nix
+  ];
+
+  # Add rspamd to redis group
+  users.users.rspamd.extraGroups = [
+    "redis"
+  ];
+
+  # Ensure redis is started before rspamd
+  systemd.services.postfix = {
+    requires = [ "redis.service" ];
+    after = [ "redis.service" ];
+  };
+
+  services.rspamd = {
+    enable = true;
+    postfix = {
+      enable = true;
+      config = {
+        smtpd_milters = [ "unix:${milterPort}" ];
+        non_smtpd_milters = [ "unix:${milterPort}" ];
+      };
+    };
+    locals."redis.conf".text = ''
+      # Redis is needed for a number of modules
+      servers = "/run/redis/redis.sock";
+    '';
+    locals."dkim_signing.conf".text = ''
+      path = "/var/secrets/$domain.$selector.dkim.key";
+      selector = "${config.networking.hostName}";
+      allow_username_mismatch = true;
+    '';
+    locals."worker-controller.inc".text = ''
+      # generate a password hash using the `rspamadm pw` command and put it here
+      # This is git safe - it's a hash, for god sake
+      password = "$2$6znhwcxm4f3aja5d4cwaj1pheayfddms$13x4n1kn8frfnnx6mwkpchi3twd9napyqpf4pyom5rrqktxdgobb";
+
+      # dovecot will use this socket to communicate with rspamd
+      # RuntimeDirectory created by systemd in nixpkgs module for rspamd
+      bind_socket = "/run/rspamd/rspamd.sock mode=0660 owner=rspamd group=dovecot2";
+
+      # you can comment this out if you don't need the web interface
+      bind_socket = "127.0.0.1:11334";
+    '';
+    locals."worker-normal.inc".text = ''
+      # we're not running rspamd in a distributed setup, so this can be disabled
+      # the proxy worker will handle all the spam filtering
+      enabled = false;
+    '';
+    locals."worker-proxy.inc".text = ''
+      # this worker will be used as postfix milter
+      milter = yes;
+
+      # RuntimeDirectory created by systemd in nixpkgs module for rspamd
+      bind_socket = "${milterPort} mode=0660 owner=rspamd group=postfix";
+
+      # the following specifies self-scan mode, for when rspamd is on the same
+      # machine as postfix
+      timeout = 120s;
+      upstream "local" {
+        default = yes;
+        self_scan = yes;
+      }
+    '';
+    locals."classifier-bayes.conf".text = ''
+      autolearn = true;
+      backend = "redis";
+    '';
+    locals."mx_check.conf".text = ''
+      enabled = true;
+    '';
+    locals."phishing.conf".text = ''
+      openphis_enabled = true;
+      phishtank_enabled = true;
+    '';
+    locals."replies.conf".text = ''
+      action = "no action";
+    '';
+    locals."url_reputation.conf".text = ''
+      # Scan URLs
+      enabled = true;
+    '';
+    locals."url_tags.conf".text = ''
+      # Redis caching of URL tags
+      enabled = true;
+    '';
+  };
+}

--- a/services/postfix/rspamd.nix
+++ b/services/postfix/rspamd.nix
@@ -43,6 +43,7 @@ in {
       allow_username_mismatch = true;
       sign_local = false;
       sign_authenticated = true;
+	  use_esld = false;
     '';
     locals."worker-controller.inc".text = ''
       # generate a password hash using the `rspamadm pw` command and put it here

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -1,0 +1,24 @@
+{
+  users.groups.redis = {};
+  users.users.redis.group = "redis";
+
+  # Create a log directory with systemd <3
+  systemd.services.redis.serviceConfig.LogsDirectory = "redis";
+
+  services.redis = {
+    enable = true;
+    port = 0;
+    unixSocket = "/run/redis/redis.sock";
+
+    # Journal
+    logfile = "/var/log/redis/redis.log";
+    syslog = false;
+
+    extraConfig = ''
+      rdbcompression yes
+      maxmemory 2G
+      maxmemory-policy allkeys-lru
+      unixsocketperm 660
+    '';
+  };
+}


### PR DESCRIPTION
Closes #1 

It's.Finally.Done.

Adds a Postfix, Dovecot, Rspamd and Mailman configuration. All aliases have also been migrated. I guess the most useful thing I can do here is describe some features.

- All users must be authenticated to send and receive mail. Port 25 is only useful for users connecting from domains other than ${tld}
- No mail is received unauthenticated for ${tld}, preventing outside sources spoofing emails to us, from our domain.
- Dovecot2 sieve scripts are configured to teach Rspamd Spam and Ham based on users moving mails to and from their Junk/Spam mailbox.
- Connections from local networks must be authenticated. There's a few reasons for this, 1 is that we do not inherently trust the users inside our network, 2 is it prevent spoofing internally, 3 is it makes it much easier to trace the sources of emails from the postfix logs.
- Mailman has its own LDAP user now (mailmgr) which is the only account allowed to spoof mail.
- Mail is now written to /var/mail/%domain/%user in MDBox format. This reduces the number of files tenfold, meaning performance will be better (less random IO on very small files). Also, the mail attachment directory is common to all users allowing dovecot to hash and deduplicate attachments on receive. For my own inbox alone, 25% of my mail was attachments, most of which were shared.
- /var/mail has come complex permissions to support dsync migrations from Maildir. See [this commit's description](https://github.com/redbrick/nix-configs/commit/66efb1e28b57ce4110e4ad69f097a23350403946)
- Rspamd does not obey HTTP proxy configuration when downloading blacklists, meaning the mail host must be able to reach the internet
- Due to the complexity of configuring Mailman + Hyperkitty, and the current webmail setup, mail + web (Apache) must be on the same host.