### PR TITLE
Fix folding at home config

### DIFF
--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -61,15 +61,11 @@ in {
   };
 
   # Enabled Spare cpu cycles to be used for folding@home
-  services.foldingAtHome = {
+  services.foldingathome = {
     enable = true;
-    nickname = "redbrick";
-    config = ''
-      <config>
-        <power v='light'/>
-        <team v='43166'/>
-      </config>
-    '';
+    user = "redbrick";
+    team = 43166;
+    extraArgs = [ "--power" "light" ];
   };
 
   # Enable LDAP


### PR DESCRIPTION
Would not compile on 20.09. The options shown on the nixOS website are for 19.09