### PR TITLE
Add Motherlode host config + libvirt

### DIFF
--- a/hosts/motherlode/configuration.nix
+++ b/hosts/motherlode/configuration.nix
@@ -6,6 +6,7 @@ in {
     ./hardware-configuration.nix
     ../../common/sysconfig.nix
     ../../services/ssh.nix
+    ../../services/libvirt.nix
   ];
 
   # This value determines the NixOS release with which your system is to be

--- a/hosts/motherlode/configuration.nix
+++ b/hosts/motherlode/configuration.nix
@@ -1,0 +1,27 @@
+{ config, pkgs, ... }:
+let
+  variables = import ../../common/variables.nix;
+in {
+  imports = [
+    ./hardware-configuration.nix
+    ../../common/sysconfig.nix
+    ../../services/ssh.nix
+  ];
+
+  # This value determines the NixOS release with which your system is to be
+  # compatible, in order to avoid breaking some software such as database
+  # servers. You should change this only after NixOS release notes say you
+  # should.
+  system.stateVersion = "20.09";
+
+  # Use the GRUB 2 boot loader.
+  boot.loader.grub.enable = true;
+  boot.loader.grub.version = 2;
+  boot.loader.grub.device = "/dev/sda";
+
+  networking = {
+    hostName = "motherlode";
+    hostId = "fccc9415";
+    defaultGateway = "192.168.0.254";
+  } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.130");
+}

--- a/hosts/motherlode/hardware-configuration.nix
+++ b/hosts/motherlode/hardware-configuration.nix
@@ -1,0 +1,22 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports =
+    [ <nixpkgs/nixos/modules/installer/scan/not-detected.nix>
+    ];
+
+  boot.initrd.availableKernelModules = [ "uhci_hcd" "ehci_pci" "ata_piix" "megaraid_sas" "usbhid" "sd_mod" "sr_mod" ];
+  boot.kernelModules = [ "kvm-intel" ];
+  boot.extraModulePackages = [ ];
+
+  fileSystems."/" =
+    { device = "/dev/disk/by-uuid/8c34aaec-4f61-4b29-a451-cd8e8d2bd394";
+      fsType = "ext4";
+    };
+
+  swapDevices =
+    [ { device = "/dev/disk/by-uuid/28c3f2fd-7b98-4bf6-a778-f73b8064c381"; }
+    ];
+
+  nix.maxJobs = lib.mkDefault 8;
+}

--- a/services/libvirt.nix
+++ b/services/libvirt.nix
@@ -1,23 +1,6 @@
-{ config, ... }:
-let
-  tld = config.redbrick.tld;
-in {
-
-  # Need a cert specifically for the listening port
-  # It's hard to get libvirt to work without tls
-  security.acme.acceptTerms = true;
-  security.acme.certs.libvirt = {
-    domain = "${config.networking.hostName}.${tld}";
-    email = "webmaster+acmelibvirt@${tld}";
-    dnsProvider = "rfc2136";
-    credentialsFile = "/var/secrets/certs.secret";
-    dnsPropagationCheck = false;
-  };
-
+{
   virtualisation.libvirtd = {
     enable = true;
     onShutdown = "shutdown";
-    extraConfig = "listen_tls = 0\nlisten_tcp = 1";
-    extraOptions = ["-l"];
   };
 }

--- a/services/libvirt.nix
+++ b/services/libvirt.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+let
+  tld = config.redbrick.tld;
+in {
+
+  # Need a cert specifically for the listening port
+  # It's hard to get libvirt to work without tls
+  security.acme.acceptTerms = true;
+  security.acme.certs.libvirt = {
+    domain = "${config.networking.hostName}.${tld}";
+    email = "webmaster+acmelibvirt@${tld}";
+    dnsProvider = "rfc2136";
+    credentialsFile = "/var/secrets/certs.secret";
+    dnsPropagationCheck = false;
+  };
+
+  virtualisation.libvirtd = {
+    enable = true;
+    onShutdown = "shutdown";
+    extraConfig = "listen_tls = 0\nlisten_tcp = 1";
+    extraOptions = ["-l"];
+  };
+}


### PR DESCRIPTION
Motherlode has always been nix but it existed before this repo. Today I went and updated it so that it is using this repo, and thus inline with the rest of the fleet (and running folding@home)

Someone needs to write up the docs page for this host. Please include this point:
- Motherlode takes ages to shut down if there are VMs with unconfigured OSes on them (IE sitting at boot screens). Try to remember to `virsh destroy` those VMs before rebooting otherwise you have to wait 5 extra minutes per VM.