### PR TITLE
Removing richie alias

### DIFF
--- a/services/postfix/aliases.nix
+++ b/services/postfix/aliases.nix
@@ -389,7 +389,6 @@
   "jennyf" = "ribbons";
   "niall.gaffney" = "gamma";
   "richard.walsh" = "koffee";
-  "richie" = "koffee";
   "vadim" = "vadimck";
   "lorcan.boyle" = "zergless";
   "robert.devereux" = "kylar";


### PR DESCRIPTION
* Removing alias mapping `richie@redbrick.dcu.ie` to `koffee@redbrick.dcu.ie` as this is an active user account.