### PR TITLE
Add env var to fix curl over https proxy

### DIFF
--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -107,6 +107,11 @@ in {
   # Add Root CA for Squid proxy
   security.pki.certificateFiles = [ ./proxycert.pem ];
 
+  # Ensure curl loads the certs so it can connect to proxy
+  environment.variables.NIX_CURL_FLAGS = let
+    cafile = config.environment.etc."ssl/certs/ca-certificates.crt".source;
+  in "--proxy-cacert ${cafile} --cacert ${cafile}";
+
   users.ldap.daemon.enable = true;
   # Increasing this limit helps with phpfpm/httpd startup issues
   systemd.services.nscd.serviceConfig.LimitNOFILE = 16384;


### PR DESCRIPTION
This will need to be rolled out to all NixOS hosts.