### PR TITLE
Require auth for login on wiki

### DIFF
--- a/services/httpd/mediawiki.nix
+++ b/services/httpd/mediawiki.nix
@@ -189,6 +189,7 @@ let
     dbPrefix = "rbwiki_";
     cacheDir = "/var/tmp/wiki";
     stateDir = "${webtree}/w/wiki";
+    needLogin = true;
   };
   wikiCfgPath = mkConfig wikiConfig;
 


### PR DESCRIPTION
A much less nuclear solution...

This might unearth bugs in the auth config as people log in more but we can fix those as they arrive.