### PR TITLE
Fix wiki login

### DIFF
--- a/services/httpd/mediawiki.nix
+++ b/services/httpd/mediawiki.nix
@@ -130,9 +130,10 @@ let
       $wgNonincludableNamespaces[] = 100;
       $wgGroupPermissions['*']['readrbonly'] = false;
       $wgNamespaceProtection[ 100 ] = array( 'readrbonly' );
-      $wgGroupPermissions['*']['createaccount']   = false;
-      $wgGroupPermissions['*']['read']            = ${if needLogin then "false" else "true"};
-      $wgGroupPermissions['*']['edit']            = false;
+      $wgGroupPermissions['*']['createaccount']     = false;
+      $wgGroupPermissions['*']['autocreateaccount'] = true;
+      $wgGroupPermissions['*']['read']              = ${if needLogin then "false" else "true"};
+      $wgGroupPermissions['*']['edit']              = false;
 
       # When you make changes to this configuration file, this will make
       # sure that cached pages are cleared.


### PR DESCRIPTION
Logins for new accounts are broken because PluggableAuth is unable to create wiki accounts on their behalf without the 'autocreateaccount' permission.

See [here](https://www.mediawiki.org/wiki/Extension:PluggableAuth#Installation) and [here](https://www.mediawiki.org/wiki/Manual:User_rights#List_of_permissions).