### PR TITLE
Add znapzend configuration

### DIFF
--- a/common/options.nix
+++ b/common/options.nix
@@ -38,5 +38,17 @@
       default = "136.206.15.3";
       type = lib.types.str;
     };
+
+    znapzendSourceDataset = lib.mkOption {
+      description = "Dataset on the local system to send to Albus";
+      example = "znfs";
+      type = lib.types.str;
+    };
+
+    znapzendDestDataset = lib.mkOption {
+      description = "Dataset on Albus to write the backup to (full path)";
+      example = "zbackup/nfs";
+      type = lib.types.str;
+    };
   };
 }

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -26,4 +26,25 @@ in {
     hostId = "92975c99";
     defaultGateway = "192.168.0.254";
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.56");
+
+  users.users.znapzend = {
+    useDefaultShell = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjw3ENwy/fBX6EOqwppSv1c0m5buvKE8OaS810BTaFo root@icarus"
+    ];
+  };
+
+  systemd.services.znapzend-permissions = {
+    description = "Configure ZFS permissions for znapzend user";
+    after = [ "zfs-import.target" ];
+    wantedBy = [ "multi-user.target" ];
+    restartIfChanged = true;
+    path = with pkgs; [ zfs ];
+    script = ''
+      zfs allow -u znapzend create,destroy,mount,receive,userprop zbackup
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+    };
+  };
 }

--- a/hosts/icarus/configuration.nix
+++ b/hosts/icarus/configuration.nix
@@ -8,6 +8,7 @@ in {
     ../../services/ssh.nix
     ../../services/gluster.nix
     ../../services/squid.nix
+    ../../services/znapzend.nix
     ../../services/ldap
     ../../services/zfsquota
   ];
@@ -39,4 +40,8 @@ in {
 
   # Sync quotas with LDAP
   redbrick.zfsquotaDataset = "zbackup";
+
+  # Configure backups
+  redbrick.znapzendSourceDataset = "zbackup";
+  redbrick.znapzendDestDataset = "zbackup/nfs";
 }

--- a/services/znapzend.nix
+++ b/services/znapzend.nix
@@ -1,0 +1,20 @@
+{ config, ... }:
+{
+  services.znapzend = {
+    enable = true;
+    pure = true;
+    autoCreation = true;
+    features = {
+      compressed = true;
+      recvu = true;
+    };
+    zetup."${config.redbrick.znapzendSourceDataset}" = {
+      plan = "1d=>1h,1m=>1d,6m=>1m";
+      recursive = true;
+      destinations.albus = {
+        host = "znapzend@albus.internal";
+        dataset = config.redbrick.znapzendDestDataset;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Closes #14 

Znapzend will create ZFS snapshots of the NFS dataset on Icarus and send them to Albus.

Currently it will keep 1 hour backups for 1 day, 1 day backups for 1 month, and 1 month backups for 6 months.

With a 1.37x compress ratio and only 1.3tb used we have ample storage for this sort of backup strategy.