### PR TITLE
Mail fixes

### DIFF
--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -1,4 +1,4 @@
-{config, pkgs, ...}:
+{config, pkgs, lib, ...}:
 let
   tld = config.redbrick.tld;
   tldCertsDir = config.security.acme.certs."${tld}".directory;

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -1,4 +1,4 @@
-{config, pkgs, lib, ...}:
+{config, pkgs, ...}:
 let
   tld = config.redbrick.tld;
   tldCertsDir = config.security.acme.certs."${tld}".directory;
@@ -49,7 +49,7 @@ in {
   # Increase ulimit due to service_auth client_limit (2000)
   systemd.services.dovecot2.serviceConfig.LimitNOFILE = 2500;
 
-  security.acme.certs."${tld}".postRun = lib.mkMerge ''
+  security.acme.certs."${tld}".postRun = ''
     systemctl restart dovecot2
   '';
 

--- a/services/dovecot/default.nix
+++ b/services/dovecot/default.nix
@@ -1,6 +1,7 @@
 {config, pkgs, ...}:
 let
   tld = config.redbrick.tld;
+  tldCertsDir = config.security.acme.certs."${tld}".directory;
 
   common = import ../../common/variables.nix;
 
@@ -48,6 +49,10 @@ in {
   # Increase ulimit due to service_auth client_limit (2000)
   systemd.services.dovecot2.serviceConfig.LimitNOFILE = 2500;
 
+  security.acme.certs."${tld}".postRun = lib.mkMerge ''
+    systemctl restart dovecot2
+  '';
+
   services.dovecot2 = {
     enable = true;
     modules = [ pigeonhole ];
@@ -57,8 +62,8 @@ in {
     enablePAM = false;
     showPAMFailure = false;
 
-    sslServerCert = "${common.certsDir}/${tld}/fullchain.pem";
-    sslServerKey = "${common.certsDir}/${tld}/key.pem";
+    sslServerCert = "${tldCertsDir}/fullchain.pem";
+    sslServerKey = "${tldCertsDir}/key.pem";
     sslCACert = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
 
     # We don't want all members to be able to read other member's mail

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -3,6 +3,8 @@
 {config, pkgs, lib, ...}:
 let
   tld = config.redbrick.tld;
+  tldCertsDir = config.security.acme.certs."${tld}".directory;
+
   common = import ../../common/variables.nix;
 
   aliases = import ./aliases.nix { inherit tld; };
@@ -81,6 +83,10 @@ in {
   security.dhparams.params.smtpd_512.bits = 512;
   security.dhparams.params.smtpd_2048.bits = 2048;
 
+  security.acme.certs."${tld}".postRun = lib.mkMerge ''
+    systemctl restart postfix
+  '';
+
   services.postfix = {
     enable = true;
     setSendmail = true;
@@ -89,8 +95,8 @@ in {
     destination = [tld "localhost"];
     recipientDelimiter = "+";
 
-    sslCert = "${common.certsDir}/${tld}/fullchain.pem";
-    sslKey = "${common.certsDir}/${tld}/key.pem";
+    sslCert = "${tldCertsDir}/fullchain.pem";
+    sslKey = "${tldCertsDir}/key.pem";
 
     # disable authentication on port 25. This port should only be used by other
     # mail servers

--- a/services/postfix/default.nix
+++ b/services/postfix/default.nix
@@ -83,7 +83,7 @@ in {
   security.dhparams.params.smtpd_512.bits = 512;
   security.dhparams.params.smtpd_2048.bits = 2048;
 
-  security.acme.certs."${tld}".postRun = lib.mkMerge ''
+  security.acme.certs."${tld}".postRun = ''
     systemctl restart postfix
   '';
 

--- a/services/postfix/mailman.nix
+++ b/services/postfix/mailman.nix
@@ -89,6 +89,7 @@ in {
       smtp_user: ${secrets.emailUser}
       smtp_pass: ${secrets.emailPassword}
       smtp_secure_mode: starttls
+      remove_dkim_headers: yes
     '';
   };
 

--- a/services/postfix/rspamd.nix
+++ b/services/postfix/rspamd.nix
@@ -41,9 +41,14 @@ in {
       path = "/var/secrets/$domain.$selector.dkim.key";
       selector = "${config.networking.hostName}";
       allow_username_mismatch = true;
+      allow_hdrfrom_mismatch = true;
       sign_local = false;
       sign_authenticated = true;
-	  use_esld = false;
+      use_esld = false;
+    '';
+    # Given the volume of logs we get from mail, this is nothing, and it's very useful.
+    locals."logging.inc".text = ''
+      debug_modules = ["dkim_signing"];
     '';
     locals."worker-controller.inc".text = ''
       # generate a password hash using the `rspamadm pw` command and put it here


### PR DESCRIPTION
DKIM signing was not being performed on mails
from redbrick users through mailman lists. This
was because rspamd was denying signing on the
mismathed domains (lists.rb. vs rb.)

Also added SSL renewal hooks to restart postfix and dovecot.