### PR TITLE
Update LDAP server configuration and add RBBackup service

### DIFF
--- a/common/ldap.nix
+++ b/common/ldap.nix
@@ -6,20 +6,20 @@
 let
   servers = [
     {
-      hostName = "m1cr0man.internal";
-      ipAddress = "192.168.0.135";
-      replicationId = 135;
+      hostName = "daedalus.internal";
+      ipAddress = "192.168.0.50";
+      replicationId = 50;
     }
     {
-      hostName = "butlerxvm.internal";
-      ipAddress = "192.168.0.136";
-      replicationId = 136;
+      hostName = "icarus.internal";
+      ipAddress = "192.168.0.150";
+      replicationId = 150;
     }
-    {
-      hostName = "albus.internal";
-      ipAddress = "192.168.0.56";
-      replicationId = 56;
-    }
+    # {
+    #   hostName = "albus.internal";
+    #   ipAddress = "192.168.0.56";
+    #   replicationId = 56;
+    # }
   ];
 in {
   redbrick.ldapServers = servers;

--- a/common/ldap.nix
+++ b/common/ldap.nix
@@ -4,23 +4,38 @@
 # LDAP failures if DNS goes down.
 { config, lib, ... }:
 let
-  servers = [
-    {
-      hostName = "daedalus.internal";
-      ipAddress = "192.168.0.50";
-      replicationId = 50;
-    }
-    {
-      hostName = "icarus.internal";
-      ipAddress = "192.168.0.150";
-      replicationId = 150;
-    }
-    {
-      hostName = "albus.internal";
-      ipAddress = "192.168.0.56";
-      replicationId = 56;
-    }
-  ];
+  servers = {
+    redbrick = [
+      {
+        hostName = "daedalus.internal";
+        ipAddress = "192.168.0.50";
+        replicationId = 50;
+      }
+      {
+        hostName = "icarus.internal";
+        ipAddress = "192.168.0.150";
+        replicationId = 150;
+      }
+      {
+        hostName = "albus.internal";
+        ipAddress = "192.168.0.56";
+        replicationId = 56;
+      }
+    ];
+    redbricktest = [
+      {
+        hostName = "m1cr0man.internal";
+        ipAddress = "192.168.0.135";
+        replicationId = 135;
+      }
+      {
+        hostName = "butlerxvm.internal";
+        ipAddress = "192.168.0.136";
+        replicationId = 136;
+      }
+    ];
+  };
+  cluster = servers.${config.redbrick.ldapCluster};
 in {
   redbrick.ldapServers = servers;
 
@@ -37,10 +52,10 @@ in {
       (lib.optional (config.services.openldap.enable) "ldap://127.0.0.1")
       ++ (builtins.map
         (srv: "ldap://${srv.hostName}")
-        servers
+        cluster
       ) ++ (builtins.map
         (srv: "ldap://${srv.ipAddress}")
-        servers
+        cluster
       )
     );
   };

--- a/common/ldap.nix
+++ b/common/ldap.nix
@@ -2,22 +2,88 @@
 # Add new servers here.
 # IP Address used instead of DNS to mitigate
 # LDAP failures if DNS goes down.
-{
-    redbrick.ldapServers = [
-        # m1cr0man.internal
-        {
-            ipAddress = "192.168.0.135";
-            replicationId = 135;
-        }
-        # butlerxvm.internal
-        {
-            ipAddress = "192.168.0.136";
-            replicationId = 136;
-        }
-        # albus.internal
-        {
-            ipAddress = "192.168.0.56";
-            replicationId = 56;
-        }
-    ];
+let
+  servers = [
+    {
+      hostName = "m1cr0man.internal";
+      ipAddress = "192.168.0.135";
+      replicationId = 135;
+    }
+    {
+      hostName = "butlerxvm.internal";
+      ipAddress = "192.168.0.136";
+      replicationId = 136;
+    }
+    {
+      hostName = "albus.internal";
+      ipAddress = "192.168.0.56";
+      replicationId = 56;
+    }
+  ];
+in {
+  redbrick.ldapServers = servers;
+
+  # Enable LDAP
+  users.ldap = {
+    enable = true;
+    daemon.enable = true;
+    timeLimit = 2;
+    base = "o=redbrick";
+    # Two maps over LDAP servers - so that IP address comes after
+    # host redundancy.
+    server = builtins.concatStringsSep " " ((builtins.map
+      (srv: "ldap://${srv.hostName}")
+      servers
+    ) ++ (builtins.map
+      (srv: "ldap://${srv.ipAddress}")
+      servers
+    ));
+  };
+
+  # Increasing this limit helps with phpfpm/httpd startup issues
+  systemd.services.nscd.serviceConfig.LimitNOFILE = 16384;
+  services.nscd.config = ''
+    # We basically use nscd as a proxy for forwarding nss requests to appropriate
+    # nss modules, as we run nscd with LD_LIBRARY_PATH set to the directory
+    # containing all such modules
+    # Note that we can not use `enable-cache no` As this will actually cause nscd
+    # to just reject the nss requests it receives, which then causes glibc to
+    # fallback to trying to handle the request by itself. Which won't work as glibc
+    # is not aware of the path in which the nss modules live.  As a workaround, we
+    # have `enable-cache yes` with an explicit ttl of 0
+    # Redbrick Modification (m1cr0man 16-nov-19): Enable the caching for passwd
+    # and group, and set reload-count to 0 to avoid unnecessary refreshes.
+    # Changed hosts cache time to 3 minutes from 10
+    server-user             nscd
+
+    enable-cache            passwd          yes
+    positive-time-to-live   passwd          120
+    negative-time-to-live   passwd          120
+    reload-count            passwd          0
+    shared                  passwd          yes
+
+    enable-cache            group           yes
+    positive-time-to-live   group           120
+    negative-time-to-live   group           120
+    reload-count            group           0
+    shared                  group           yes
+
+    enable-cache            netgroup        yes
+    positive-time-to-live   netgroup        0
+    negative-time-to-live   netgroup        0
+    reload-count            netgroup        0
+    shared                  netgroup        yes
+
+    enable-cache            hosts           yes
+    positive-time-to-live   hosts           180
+    negative-time-to-live   hosts           000
+    reload-count            hosts           0
+    shared                  hosts           yes
+
+    enable-cache            services        yes
+    positive-time-to-live   services        0
+    negative-time-to-live   services        0
+    reload-count            services        0
+    shared                  services        yes
+  '';
 }

--- a/common/ldap.nix
+++ b/common/ldap.nix
@@ -1,0 +1,23 @@
+# Configuration of LDAP cluster.
+# Add new servers here.
+# IP Address used instead of DNS to mitigate
+# LDAP failures if DNS goes down.
+{
+    redbrick.ldapServers = [
+        # m1cr0man.internal
+        {
+            ipAddress = "192.168.0.135";
+            replicationId = 135;
+        }
+        # butlerxvm.internal
+        {
+            ipAddress = "192.168.0.136";
+            replicationId = 136;
+        }
+        # albus.internal
+        {
+            ipAddress = "192.168.0.56";
+            replicationId = 56;
+        }
+    ];
+}

--- a/common/ldap.nix
+++ b/common/ldap.nix
@@ -15,11 +15,11 @@ let
       ipAddress = "192.168.0.150";
       replicationId = 150;
     }
-    # {
-    #   hostName = "albus.internal";
-    #   ipAddress = "192.168.0.56";
-    #   replicationId = 56;
-    # }
+    {
+      hostName = "albus.internal";
+      ipAddress = "192.168.0.56";
+      replicationId = 56;
+    }
   ];
 in {
   redbrick.ldapServers = servers;

--- a/common/options.nix
+++ b/common/options.nix
@@ -1,54 +1,65 @@
 { lib, ... }:
+with lib;
 {
   options.redbrick = {
-    tld = lib.mkOption {
+    tld = mkOption {
       description = "Source of truth of TLD for entire Nix config";
       default = "redbrick.dcu.ie";
-      type = lib.types.nullOr lib.types.str;
+      type = types.nullOr types.str;
     };
 
-    skipCustomVhosts = lib.mkOption {
+    skipCustomVhosts = mkOption {
       description = "Skip all vhosts that are not based on the TLD. Useful for development boxes";
       default = false;
       defaultText = "False (compile the vhosts)";
-      type = lib.types.nullOr lib.types.bool;
+      type = types.nullOr types.bool;
     };
 
-    ldapSlaveTo = lib.mkOption {
-      description = "If this host is going to be an LDAP slave, set this to a hostname";
-      default = null;
-      defaultText = "Null (this is a master)";
-      type = lib.types.nullOr lib.types.str;
+    ldapServers = mkOption {
+      description = "Configuration of LDAP servers to cluster together";
+      default = [];
+      type = types.listOf (types.submodule {
+        options = {
+          ipAddress = mkOption {
+            description = "IP address of the LDAP host";
+            type = types.str;
+          };
+          replicationId = mkOption {
+            description = "MAX 3 digit number to use as the host's replication ID";
+            type = types.int;
+          };
+        };
+      });
     };
 
-    smtpBindAddress = lib.mkOption {
+    smtpBindAddress = mkOption {
       description = "Address that Postfix expects to send and receive mail on";
       default = "192.168.0.158";
-      type = lib.types.str;
+      type = types.str;
     };
 
-    smtpExternalAddress = lib.mkOption {
+    smtpExternalAddress = mkOption {
       description = "The appropriate public IP forwarding port 587/993 for this mail host";
       default = "136.206.15.3";
-      type = lib.types.str;
+      type = types.str;
     };
 
-    ircServerAddress = lib.mkOption {
+    ircServerAddress = mkOption {
       description = "The appropriate public IP forwarding port 6697 for this IRC host";
       default = "136.206.15.3";
-      type = lib.types.str;
+      type = types.str;
     };
 
-    znapzendSourceDataset = lib.mkOption {
+    znapzendSourceDataset = mkOption {
       description = "Dataset on the local system to send to Albus";
       example = "znfs";
-      type = lib.types.str;
+      type = types.str;
     };
 
-    znapzendDestDataset = lib.mkOption {
+    znapzendDestDataset = mkOption {
       description = "Dataset on Albus to write the backup to (full path)";
       example = "zbackup/nfs";
-      type = lib.types.str;
+      type = types.str;
     };
   };
 }

--- a/common/options.nix
+++ b/common/options.nix
@@ -20,6 +20,10 @@ with lib;
       default = [];
       type = types.listOf (types.submodule {
         options = {
+          hostName = mkOption {
+            description = "DNS name of the LDAP host";
+            type = types.str;
+          };
           ipAddress = mkOption {
             description = "IP address of the LDAP host";
             type = types.str;

--- a/common/options.nix
+++ b/common/options.nix
@@ -71,6 +71,35 @@ with lib;
       example = "zbackup/nfs";
       type = types.str;
     };
+
+    rbbackup = with types; {
+      destination = mkOption {
+        description = "Where to rsync the backup data to.";
+        default = "rbbackup@albus.internal:/zbackup/generic/${config.networking.hostName}/";
+        type = str;
+      };
+
+      sources = mkOption {
+        description = "Paths on the current system to be backed up.";
+        default = [];
+        type = listOf str;
+      };
+
+      commands = mkOption {
+        description = (
+          "Commands to run before commencing copy of backups. Files created"
+          + " in the current working directory will be deleted after backups are completed."
+        );
+        default = "";
+        type = str;
+      };
+
+      extraPackages = mkOption {
+        description = "Packages to make available in the backup commands scripts.";
+        default = [];
+        type = listOf path;
+      };
+    };
   };
 
   config.assertions = [

--- a/common/options.nix
+++ b/common/options.nix
@@ -1,11 +1,11 @@
-{ lib, ... }:
+{ config, lib, ... }:
 with lib;
 {
   options.redbrick = {
     tld = mkOption {
       description = "Source of truth of TLD for entire Nix config";
       default = "redbrick.dcu.ie";
-      type = types.nullOr types.str;
+      type = types.str;
     };
 
     skipCustomVhosts = mkOption {
@@ -18,22 +18,28 @@ with lib;
     ldapServers = mkOption {
       description = "Configuration of LDAP servers to cluster together";
       default = [];
-      type = types.listOf (types.submodule {
+      type = with types; attrsOf (listOf (submodule {
         options = {
           hostName = mkOption {
             description = "DNS name of the LDAP host";
-            type = types.str;
+            type = str;
           };
           ipAddress = mkOption {
             description = "IP address of the LDAP host";
-            type = types.str;
+            type = str;
           };
           replicationId = mkOption {
             description = "MAX 3 digit number to use as the host's replication ID";
-            type = types.int;
+            type = int;
           };
         };
-      });
+      }));
+    };
+
+    ldapCluster = mkOption {
+      description = "LDAP Cluster this host should utilise/be part of. Must be in config.redbrick.ldapServers.";
+      default = "redbrick";
+      type = types.str;
     };
 
     smtpBindAddress = mkOption {
@@ -66,4 +72,11 @@ with lib;
       type = types.str;
     };
   };
+
+  config.assertions = [
+    {
+      assertion = hasAttr config.redbrick.ldapCluster config.redbrick.ldapServers;
+      message = "The ldapCluster ${config.redbrick.ldapCluster} is not configured in config.redbrick.ldapServers";
+    }
+  ];
 }

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -7,6 +7,7 @@ in {
     ./options.nix
     ./ldap.nix
     ../packages/overlays
+    ../services/rbbackup.nix
   ];
 
   time.timeZone = "Europe/Dublin";

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -47,6 +47,9 @@ in {
   services.prometheus.exporters.node = {
     enable = true;
     openFirewall = true;
+    # This is a temporary fix for an upstream bug. Try removing it and rebuilding config
+    # whenever you can.
+    firewallFilter = "-p tcp -m tcp --dport 9100";
     enabledCollectors = [
       "systemd"
       "conntrack"

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -5,6 +5,7 @@ let
 in {
   imports = [
     ./options.nix
+    ./ldap.nix
     ../packages/overlays
   ];
 

--- a/common/sysconfig.nix
+++ b/common/sysconfig.nix
@@ -74,12 +74,6 @@ in {
     extraArgs = [ "--power" "light" ];
   };
 
-  # Enable LDAP
-  users.ldap.enable = true;
-  users.ldap.timeLimit = 2;
-  users.ldap.server = "ldap://${common.ldapHostIp}/";
-  users.ldap.base = "o=redbrick";
-
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
@@ -117,52 +111,4 @@ in {
   environment.variables.NIX_CURL_FLAGS = let
     cafile = config.environment.etc."ssl/certs/ca-certificates.crt".source;
   in "--proxy-cacert ${cafile} --cacert ${cafile}";
-
-  users.ldap.daemon.enable = true;
-  # Increasing this limit helps with phpfpm/httpd startup issues
-  systemd.services.nscd.serviceConfig.LimitNOFILE = 16384;
-  services.nscd.config = ''
-    # We basically use nscd as a proxy for forwarding nss requests to appropriate
-    # nss modules, as we run nscd with LD_LIBRARY_PATH set to the directory
-    # containing all such modules
-    # Note that we can not use `enable-cache no` As this will actually cause nscd
-    # to just reject the nss requests it receives, which then causes glibc to
-    # fallback to trying to handle the request by itself. Which won't work as glibc
-    # is not aware of the path in which the nss modules live.  As a workaround, we
-    # have `enable-cache yes` with an explicit ttl of 0
-    # Redbrick Modification (m1cr0man 16-nov-19): Enable the caching for passwd
-    # and group, and set reload-count to 0 to avoid unnecessary refreshes.
-    # Changed hosts cache time to 3 minutes from 10
-    server-user             nscd
-
-    enable-cache            passwd          yes
-    positive-time-to-live   passwd          120
-    negative-time-to-live   passwd          120
-    reload-count            passwd          0
-    shared                  passwd          yes
-
-    enable-cache            group           yes
-    positive-time-to-live   group           120
-    negative-time-to-live   group           120
-    reload-count            group           0
-    shared                  group           yes
-
-    enable-cache            netgroup        yes
-    positive-time-to-live   netgroup        0
-    negative-time-to-live   netgroup        0
-    reload-count            netgroup        0
-    shared                  netgroup        yes
-
-    enable-cache            hosts           yes
-    positive-time-to-live   hosts           180
-    negative-time-to-live   hosts           000
-    reload-count            hosts           0
-    shared                  hosts           yes
-
-    enable-cache            services        yes
-    positive-time-to-live   services        0
-    negative-time-to-live   services        0
-    reload-count            services        0
-    shared                  services        yes
-  '';
 }

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -33,6 +33,9 @@ in {
   # Keep longer monthly snapshots
   services.zfs.autoSnapshot.monthly = lib.mkForce 3;
 
+  # Albus _is_ the backup hosts - change rbbackup destination
+  redbrick.rbbackup.destination = "/zbackup/generic/albus/";
+
   users.users.rbbackup = {
     useDefaultShell = true;
     openssh.authorizedKeys.keys = [

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -6,6 +6,7 @@ in {
     ./hardware-configuration.nix
     ../../common/sysconfig.nix
     ../../services/ssh.nix
+    ../../services/ldap
   ];
 
   # This value determines the NixOS release with which your system is to be
@@ -26,6 +27,8 @@ in {
     hostId = "92975c99";
     defaultGateway = "192.168.0.254";
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.56");
+
+  services.openldap.urlList = [ "ldap://192.168.0.56:389" ];
 
   users.users.znapzend = {
     useDefaultShell = true;

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -38,6 +38,8 @@ in {
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHM+HZVUPkFX/Xlxla/2JYpFrt2vEG2nJVcjRpJhGU3c root@daedalus"
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjw3ENwy/fBX6EOqwppSv1c0m5buvKE8OaS810BTaFo root@icarus"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOLnjvcD8MnRKf5YDvKqDWK+kGMfYhSb9l54jW8nd0H1 root@m1cr0man"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBvBThPI3TmXVOKrY39l0rFLOdaLl0a0Xh/IaRQ+tAA+ root@butlerxvm"
     ];
   };
 
@@ -49,6 +51,7 @@ in {
     path = with pkgs; [ zfs ];
     script = ''
       zfs allow -u rbbackup create,destroy,mount,receive,userprop zbackup
+      chown -R rbbackup /zbackup/generic
     '';
     serviceConfig = {
       Type = "oneshot";

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -30,21 +30,22 @@ in {
 
   services.openldap.urlList = [ "ldap://192.168.0.56:389" ];
 
-  users.users.znapzend = {
+  users.users.rbbackup = {
     useDefaultShell = true;
     openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHM+HZVUPkFX/Xlxla/2JYpFrt2vEG2nJVcjRpJhGU3c root@daedalus"
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGjw3ENwy/fBX6EOqwppSv1c0m5buvKE8OaS810BTaFo root@icarus"
     ];
   };
 
-  systemd.services.znapzend-permissions = {
-    description = "Configure ZFS permissions for znapzend user";
+  systemd.services.rbbackup-permissions = {
+    description = "Configure ZFS permissions for rbbackup user";
     after = [ "zfs-import.target" ];
     wantedBy = [ "multi-user.target" ];
     restartIfChanged = true;
     path = with pkgs; [ zfs ];
     script = ''
-      zfs allow -u znapzend create,destroy,mount,receive,userprop zbackup
+      zfs allow -u rbbackup create,destroy,mount,receive,userprop zbackup
     '';
     serviceConfig = {
       Type = "oneshot";

--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, ... }:
+{ config, pkgs, lib, ... }:
 let
   variables = import ../../common/variables.nix;
 in {
@@ -29,6 +29,9 @@ in {
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.56");
 
   services.openldap.urlList = [ "ldap://192.168.0.56:389" ];
+
+  # Keep longer monthly snapshots
+  services.zfs.autoSnapshot.monthly = lib.mkForce 3;
 
   users.users.rbbackup = {
     useDefaultShell = true;

--- a/hosts/albus/hardware-configuration.nix
+++ b/hosts/albus/hardware-configuration.nix
@@ -25,6 +25,11 @@
       fsType = "vfat";
     };
 
+  fileSystems."/zbackup/generic" =
+    { device = "zbackup/generic";
+      fsType = "zfs";
+    };
+
   swapDevices =
     [ { device = "/dev/disk/by-uuid/3bb3b7df-a7eb-402f-91a7-037403d36d05"; }
     ];

--- a/hosts/butlerxvm/configuration.nix
+++ b/hosts/butlerxvm/configuration.nix
@@ -5,6 +5,7 @@
     ../../services/ssh.nix
     ../../services/prometheus.nix
     ../../services/promtail.nix
+    ../../services/ldap
   ];
 
   # This value determines the NixOS release with which your system is to be
@@ -27,4 +28,6 @@
       prefixLength = 24;
     }];
   };
+
+  services.openldap.urlList = [ "ldap://192.168.0.136:389" ];
 }

--- a/hosts/butlerxvm/configuration.nix
+++ b/hosts/butlerxvm/configuration.nix
@@ -29,5 +29,7 @@
     }];
   };
 
+  # Is an LDAP server - set cluster and server's listen address
+  redbrick.ldapCluster = "redbricktest";
   services.openldap.urlList = [ "ldap://192.168.0.136:389" ];
 }

--- a/hosts/daedalus/configuration.nix
+++ b/hosts/daedalus/configuration.nix
@@ -27,4 +27,6 @@ in {
     hostId = "0f127302";
     defaultGateway = "192.168.0.254";
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.50");
+
+  services.openldap.urlList = [ "ldap://192.168.0.50:389" ];
 }

--- a/hosts/icarus/configuration.nix
+++ b/hosts/icarus/configuration.nix
@@ -33,6 +33,8 @@ in {
     defaultGateway = "192.168.0.254";
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.150");
 
+  services.openldap.urlList = [ "ldap://192.168.0.150:389" ];
+
   # Icarus is providing /storage for now
   services.nfs.server.exports = ''
     /zbackup  *(sec=sys,rw,no_subtree_check,no_root_squash)

--- a/hosts/icarus/configuration.nix
+++ b/hosts/icarus/configuration.nix
@@ -33,9 +33,6 @@ in {
     defaultGateway = "192.168.0.254";
   } // (variables.bondConfig [ "eno1" "eno2" ] "192.168.0.150");
 
-  # Set as ldap slave to daedalus
-  redbrick.ldapSlaveTo = "daedalus.internal";
-
   # Icarus is providing /storage for now
   services.nfs.server.exports = ''
     /zbackup  *(sec=sys,rw,no_subtree_check,no_root_squash)

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -40,6 +40,8 @@
   redbrick.smtpBindAddress = "192.168.0.135";
   redbrick.smtpExternalAddress = "136.206.15.5";
 
+  services.openldap.urlList = [ "ldap://192.168.0.135:389" ];
+
   users.users.lucasade = {
     isNormalUser = true;
     home = "/home/lucasade";

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -10,6 +10,7 @@
     ../../services/dovecot
     ../../services/certs
     ../../services/postgres.nix
+    ../../services/ldap
   ];
 
   # This value determines the NixOS release with which your system is to be

--- a/hosts/m1vm/configuration.nix
+++ b/hosts/m1vm/configuration.nix
@@ -40,6 +40,8 @@
   redbrick.smtpBindAddress = "192.168.0.135";
   redbrick.smtpExternalAddress = "136.206.15.5";
 
+  # Is an LDAP server - set cluster and server's listen address
+  redbrick.ldapCluster = "redbricktest";
   services.openldap.urlList = [ "ldap://192.168.0.135:389" ];
 
   users.users.lucasade = {

--- a/services/ldap/README.md
+++ b/services/ldap/README.md
@@ -1,0 +1,38 @@
+# OpenLDAP Server
+
+Database for user credentials.
+
+## Kickstarting a new Cluster
+
+This only needs to be performed when there are no existing LDAP servers.
+
+- Generate some passwords for root and slurpd (replication user)
+
+```bash
+# Create a password for root (and save it to the passwordsafe).
+slappasswd
+echo -n 'thenewhash' > /var/secrets/ldap.secret
+# Create a password for slurpd. -n removes new line
+echo -n 'mynewpassword' > /var/secrets/slurpd.pwd.secret
+# Generate a hash for the new password
+slappasswd
+echo -n 'thenewhash' > /var/secrets/slurpd.secret
+# Fix permissions
+chmod 400 /var/secrets/slurpd*.secret /var/secrets/ldap.secret
+```
+
+- Add an entry in [ldap.nix](../../common/ldap.nix) servers array.
+- Import the ldap service in the host's configuration.nix.
+- Once running, import the initialise.ldif like so:
+
+```bash
+ldapadd -vc -x -f initialise.ldif -D cn=root,ou=services,o=redbrick -W
+```
+
+## Adding new hosts
+
+- Copy the secret files mentioned above from an existing host to the new host.
+- Add an entry in [ldap.nix](../../common/ldap.nix) servers array.
+- Import the ldap service in the host's configuration.nix.
+
+That's it! On startup, it will self replicate from the existing server(s).

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -16,10 +16,12 @@ in {
 
     settings = {
       attrs = {
-        olcLogLevel = "Sync Stats";
         olcServerID = builtins.map (srv: (
           "${builtins.toString srv.replicationId} ldap://${srv.ipAddress}:389"
         )) config.redbrick.ldapServers;
+        olcLogLevel = "0";
+        # Used for debugging
+        # olcLogLevel = "Sync Stats";
         # Used in emergencies
         # olcReadOnly = "TRUE";
       };

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -8,7 +8,7 @@ let
   baseDN = "o=redbrick";
   rootDN = "cn=root,ou=services,o=redbrick";
   slurpdDN = "cn=slurpd,ou=services,${baseDN}";
-  slurpdpwFile = "/var/secrets/slurpd.secret";
+  slurpdpwFile = "/var/secrets/slurpd.pwd.secret";
   dbDirectory = "/var/db/openldap";
 in {
   services.openldap = {
@@ -16,7 +16,7 @@ in {
 
     settings = {
       attrs = {
-        olcLogLevel = "sync";
+        olcLogLevel = "Sync Stats";
         olcServerID = builtins.map (srv: (
           "${builtins.toString srv.replicationId} ldap://${srv.ipAddress}:389"
         )) config.redbrick.ldapServers;
@@ -38,12 +38,12 @@ in {
           olcSizeLimit = "unlimited";
           olcLastMod = "TRUE";
           olcAccess = [
-            "{0}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by dn.exact=${rootDN} manage"
-            "{2}to dn.children=ou=accounts,${baseDN}  attrs=cn  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
-            "{3}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
-            "{4}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{5}to attrs=gecos,loginShell  by self write  by * read"
-            "{6}to *  by * read"
+            "{0}to dn.children=ou=accounts,${baseDN}  attrs=cn  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
+            "{1}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{2}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
+            "{3}to attrs=gecos,loginShell  by self write  by * read"
+            "{4}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by * none"
+            "{5}to *  by * read"
           ];
         };
         "olcDatabase={0}config".attrs = {
@@ -69,7 +69,7 @@ in {
               "rid=${lib.fixedWidthNumber 3 srv.replicationId} provider=ldap://${srv.ipAddress}:389"
               + " searchbase=\"${baseDN}\" scope=sub"
               + " bindmethod=simple binddn=\"${slurpdDN}\" credentials=\"${lib.fileContents slurpdpwFile}\""
-              + " type=refreshOnly interval=00:00:00:10 retry=\"5 5 300 +\" timeout=1 network-timeout=5"
+              + " type=refreshOnly interval=00:00:00:10 retry=\"15 20 60 +\""
             )) config.redbrick.ldapServers;
             olcDbIndex = [
               "entryUUID  eq"

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -6,7 +6,8 @@
 let
   rootpwFile = "/var/secrets/ldap.secret";
   baseDN = "o=redbrick";
-  slurpdDN = "uid=slurpd,ou=services,${baseDN}";
+  rootDN = "cn=root,ou=services,o=redbrick";
+  slurpdDN = "cn=slurpd,ou=services,${baseDN}";
   slurpdpwFile = "/var/secrets/slurpd.secret";
   dbDirectory = "/var/db/openldap";
 in {
@@ -37,12 +38,11 @@ in {
           olcSizeLimit = "unlimited";
           olcLastMod = "TRUE";
           olcAccess = [
-            "{0}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage"
-            "{1}to dn.children=ou=2002,ou=accounts,${baseDN}  by dn.regex=cn=root,ou=ldap,${baseDN} write by * none"
-            "{2}to dn.children=ou=accounts,${baseDN}  attrs=cn  by dn.regex=cn=root,ou=ldap,${baseDN} write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
-            "{3}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=root,ou=ldap,${baseDN} write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
-            "{4}to attrs=userPassword  by dn.regex=cn=root,ou=ldap,${baseDN} write continue  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{5}to attrs=gecos,loginShell  by dn.regex=cn=root,ou=ldap,${baseDN} write continue  by self write  by * read"
+            "{0}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by dn.exact=${rootDN} manage"
+            "{2}to dn.children=ou=accounts,${baseDN}  attrs=cn write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
+            "{3}to attrs=yearsPaid,year,course,id,newbie,altmail write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{4}to attrs=userPassword write continue  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
+            "{5}to attrs=gecos,loginShell write continue  by self write  by * read"
             "{6}to *  by * read"
           ];
         };
@@ -61,7 +61,7 @@ in {
             olcMonitoring = "TRUE";
             olcDbDirectory = dbDirectory;
             olcSuffix = baseDN;
-            olcRootDN = "cn=root,ou=ldap,${baseDN}";
+            olcRootDN = rootDN;
             olcRootPW = {
               path = rootpwFile;
             };

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -35,7 +35,7 @@ in {
         olcServerID = builtins.map (srv: (
           "${builtins.toString srv.replicationId} ldap://${srv.ipAddress}:389"
         )) config.redbrick.ldapServers;
-        olcLogLevel = "0";
+        olcLogLevel = "Config";
         # Used for debugging
         # olcLogLevel = "Sync Stats";
         # Used in emergencies

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -10,6 +10,7 @@ let
   slurpdDN = "uid=slurpd,ou=services,${baseDN}";
   slurpdpwFile = "/var/secrets/slurpd.pwd.secret";
   dbDirectory = "/var/db/openldap";
+  cluster = config.redbrick.ldapServers.${config.redbrick.ldapCluster};
 in {
   # Enable quick graceful shutdown
   systemd.services.openldap.serviceConfig.KillSignal = "SIGINT";
@@ -34,8 +35,8 @@ in {
       attrs = {
         olcServerID = builtins.map (srv: (
           "${builtins.toString srv.replicationId} ldap://${srv.ipAddress}:389"
-        )) config.redbrick.ldapServers;
-        olcLogLevel = "Config";
+        )) cluster;
+        olcLogLevel = "0";
         # Used for debugging
         # olcLogLevel = "Sync Stats";
         # Used in emergencies
@@ -87,7 +88,7 @@ in {
               + " searchbase=\"${baseDN}\" scope=sub"
               + " bindmethod=simple binddn=\"${slurpdDN}\" credentials=\"${lib.fileContents slurpdpwFile}\""
               + " type=refreshOnly interval=00:00:00:10 retry=\"15 20 60 +\""
-            )) config.redbrick.ldapServers;
+            )) cluster;
             olcDbIndex = [
               "entryUUID  eq"
               "entryCSN  eq"

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -108,5 +108,13 @@ in {
     };
   };
 
+  # Configure backups of LDAP
+  redbrick.rbbackup.sources = [ "ldap.ldif.gz" ];
+  redbrick.rbbackup.extraPackages = with pkgs; [ openldap gzip ];
+  redbrick.rbbackup.commands = ''
+    ldapsearch -b o=redbrick -xLLL -D ${slurpdDN} -y ${slurpdpwFile} | gzip -8 > ldap.ldif.gz
+    chmod 400 ldap.ldif.gz
+  '';
+
   networking.firewall.allowedTCPPorts = [ 389 ];
 }

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -13,6 +13,8 @@ let
 in {
   services.openldap = {
     enable = true;
+    # Host-specific listening IP should go into host's configuration.nix
+    urlList = [ "ldap://127.0.0.1:389" ];
 
     settings = {
       attrs = {
@@ -40,12 +42,11 @@ in {
           olcSizeLimit = "unlimited";
           olcLastMod = "TRUE";
           olcAccess = [
-            "{0}to dn.children=ou=accounts,${baseDN}  attrs=cn  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
-            "{1}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
-            "{2}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{3}to attrs=gecos,loginShell  by self write  by * read"
-            "{4}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by * none"
-            "{5}to *  by * read"
+            "{0}to attrs=cn,yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{1}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
+            "{2}to attrs=gecos,loginShell  by self write"
+            "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage"
+            "{4}to *  by * read"
           ];
         };
         "olcDatabase={0}config".attrs = {
@@ -76,8 +77,8 @@ in {
             olcDbIndex = [
               "entryUUID  eq"
               "entryCSN  eq"
+              "uid  eq"
             ];
-            # TODO figure out how to set this correctly...
             olcMirrorMode = "TRUE";
           };
           children = {

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -11,6 +11,9 @@ let
   slurpdpwFile = "/var/secrets/slurpd.pwd.secret";
   dbDirectory = "/var/db/openldap";
 in {
+  # Enable quick graceful shutdown
+  systemd.services.openldap.serviceConfig.KillSignal = "SIGINT";
+
   services.openldap = {
     enable = true;
     # Host-specific listening IP should go into host's configuration.nix

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -44,8 +44,8 @@ in {
           olcAccess = [
             "{0}to attrs=cn,yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
             "{1}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{2}to attrs=gecos,loginShell  by self write"
-            "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage"
+            "{2}to attrs=gecos,loginShell  by self write  by * read"
+            "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by users read"
             "{4}to *  by * read"
           ];
         };

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -39,10 +39,10 @@ in {
           olcLastMod = "TRUE";
           olcAccess = [
             "{0}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by dn.exact=${rootDN} manage"
-            "{2}to dn.children=ou=accounts,${baseDN}  attrs=cn write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
-            "{3}to attrs=yearsPaid,year,course,id,newbie,altmail write  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
-            "{4}to attrs=userPassword write continue  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{5}to attrs=gecos,loginShell write continue  by self write  by * read"
+            "{2}to dn.children=ou=accounts,${baseDN}  attrs=cn  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read by * none"
+            "{3}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{4}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
+            "{5}to attrs=gecos,loginShell  by self write  by * read"
             "{6}to *  by * read"
           ];
         };

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -45,10 +45,10 @@ in {
           olcSizeLimit = "unlimited";
           olcLastMod = "TRUE";
           olcAccess = [
-            "{0}to attrs=cn,yearsPaid,year,course,id,newbie,altmail  by dn.exact=${slurpdDN} manage  by dn.exact=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{0}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.exact=${slurpdDN} manage  by dn.exact=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
             "{1}to attrs=userPassword  by dn.exact=${slurpdDN} manage  by dn.exact=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
             "{2}to attrs=gecos,loginShell  by dn.exact=${slurpdDN} manage  by self write  by * read"
-            "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by users read"
+            "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by * read"
             "{4}to *  by * read"
           ];
         };

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -7,12 +7,23 @@ let
   rootpwFile = "/var/secrets/ldap.secret";
   baseDN = "o=redbrick";
   rootDN = "cn=root,ou=services,o=redbrick";
-  slurpdDN = "cn=slurpd,ou=services,${baseDN}";
+  slurpdDN = "uid=slurpd,ou=services,${baseDN}";
   slurpdpwFile = "/var/secrets/slurpd.pwd.secret";
   dbDirectory = "/var/db/openldap";
 in {
   # Enable quick graceful shutdown
   systemd.services.openldap.serviceConfig.KillSignal = "SIGINT";
+
+  # Create DB_CONFIG file on startup
+  systemd.services.openldap.preStart = ''
+    mkdir -p ${dbDirectory}
+    cat > ${dbDirectory}/DB_CONFIG << EOF
+    set_cachesize 0 2097152 0
+    set_lk_max_objects 1500
+    set_lk_max_locks 1500
+    set_lk_max_lockers 1500
+    EOF
+  '';
 
   services.openldap = {
     enable = true;

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -10,12 +10,7 @@ let
   dbDirectory = "/var/db/openldap";
 in {
   services.openldap = {
-    inherit rootpwFile;
     enable = true;
-    suffix = "o=redbrick";
-    rootdn = "cn=root,ou=ldap,o=redbrick";
-    defaultSchemas = false; # We don't use the nis.schema
-    database = "hdb";
 
     settings = {
       attrs = {
@@ -25,12 +20,12 @@ in {
       };
       children = {
         "cn=schema".includes = [
-          "${pkgs.openldap.out}/etc/schema/core.schema"
-          "${pkgs.openldap.out}/etc/schema/cosine.schema"
-          "${pkgs.openldap.out}/etc/schema/inetorgperson.schema"
-          "${./schema/common.schema}"
-          "${./schema/system.schema}"
-          "${./schema/userdb.schema}"
+          "${pkgs.openldap.out}/etc/schema/core.ldif"
+          "${pkgs.openldap.out}/etc/schema/cosine.ldif"
+          "${pkgs.openldap.out}/etc/schema/inetorgperson.ldif"
+          "${./schema/common.ldif}"
+          "${./schema/system.ldif}"
+          "${./schema/userdb.ldif}"
         ];
         "olcDatabase={-1}frontend".attrs = {
           objectClass = [ "olcDatabaseConfig" "olcFrontendConfig" ];
@@ -65,92 +60,21 @@ in {
             olcRootPW = {
               path = rootpwFile;
             };
-          };
+          } // (lib.optionalAttrs (config.redbrick.ldapSlaveTo != null) {
+              olcSyncrepl = "rid=000 provider=ldap://${config.redbrick.ldapSlaveTo}:389 bindmethod=simple timeout=0 network-timeout=0 binddn=\"cn=slurpd,ou=ldap,o=redbrick\" credentials=\"${lib.fileContents slurpdpwFile}\" keepalive=0:0:0 starttls=no filter=\"(objectclass=*)\" searchbase=\"o=redbrick\" scope=sub attrs=\"*,+\" schemachecking=off type=refreshAndPersist retry=\"5 5 300 +\"";
+              olcMirrorMode = "FALSE";
+          });
           children = {
             # TODO test + repl config
-            "olcOverlay={0}syncprov".attrs = if (config.redbrick.ldapSlaveTo == null) then {
+            "olcOverlay={0}syncprov".attrs = lib.optionalAttrs (config.redbrick.ldapSlaveTo == null) {
               objectClass = [ "olcOverlayConfig" "olcSyncProvConfig" ];
               olcOverlay = "{0}syncprov";
               olcSpCheckpoint = "100 10";
-              olcAccess = [ "{0}to * by * read break" ];
-            } else {
-              olcSyncrepl = "rid=000 provider=ldap://${config.redbrick.ldapSlaveTo}:389 bindmethod=simple timeout=0 network-timeout=0 binddn=\"cn=slurpd,ou=ldap,o=redbrick\" credentials=\"${lib.fileContents slurpdpwFile}\" keepalive=0:0:0 starttls=no filter=\"(objectclass=*)\" searchbase=\"o=redbrick\" scope=sub attrs=\"*,+\" schemachecking=off type=refreshAndPersist retry=\"5 5 300 +\"";
-              olcMirrorMode = "FALSE";
             };
           };
+        };
       };
     };
-
-    extraDatabaseConfig = ''
-      cachesize 100000
-    '' + (if (config.redbrick.ldapSlaveTo == null) then ''
-
-      # Master config
-      overlay syncprov
-      syncprov-checkpoint 100 10
-    '' else ''
-      syncrepl rid=000
-        provider=ldap://${config.redbrick.ldapSlaveTo}:389
-        type=refreshAndPersist
-        retry="5 5 300 +"
-        attrs="*,+"
-        binddn="cn=slurpd,ou=ldap,o=redbrick"
-        bindmethod=simple
-        credentials=${lib.fileContents slurpdpwFile}
-        searchbase="o=redbrick"
-    '');
-    extraConfig = ''
-      include ${pkgs.openldap.out}/etc/schema/core.schema
-      include ${pkgs.openldap.out}/etc/schema/cosine.schema
-      include ${pkgs.openldap.out}/etc/schema/inetorgperson.schema
-      include ${./schema/common.schema}
-      include ${./schema/system.schema}
-      include ${./schema/userdb.schema}
-
-      backend hdb
-      lastmod on
-
-      sizelimit unlimited
-      loglevel ${config.services.openldap.logLevel}
-
-      # ACLs
-      access to dn.children="ou=2002,ou=accounts,o=redbrick"
-        by dn.regex="cn=root,ou=ldap,o=redbrick" write
-        by dn.regex="cn=slurpd,ou=ldap,o=redbrick" read
-        by * none
-
-      access to dn.children="ou=accounts,o=redbrick" attrs=cn
-        by dn.regex="cn=root,ou=ldap,o=redbrick" write
-        by dn.regex="cn=slurpd,ou=ldap,o=redbrick" read
-        by dn.regex="cn=mediawiki,ou=reserved,o=redbrick" read
-        by self read
-        by * none
-
-      access to attrs=yearsPaid,year,course,id,newbie,altmail
-        by dn.regex="cn=root,ou=ldap,o=redbrick" write
-        by dn.regex="cn=slurpd,ou=ldap,o=redbrick" read
-        by dn.regex="cn=mediawiki,ou=reserved,o=redbrick" read
-        by self read
-        by * none
-
-      access to attrs=userPassword
-        by dn.regex="cn=root,ou=ldap,o=redbrick" write continue
-        by dn.regex="cn=slurpd,ou=ldap,o=redbrick" read
-        by dn.regex="cn=dovecot,ou=reserved,o=redbrick" read
-        by self write
-        by anonymous auth
-        by * none
-
-      access to attrs=gecos,loginShell
-        by dn.regex="cn=root,ou=ldap,o=redbrick" write continue
-        by dn.regex="cn=slurpd,ou=ldap,o=redbrick" read
-        by self write
-        by * read
-
-      # Default ACL
-      access to *
-        by * read
-    '';
   };
 
   networking.firewall.allowedTCPPorts = [ 389 ];

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -7,6 +7,7 @@
 let
   rootpwFile = "/var/secrets/ldap.secret";
   slurpdpwFile = "/var/secrets/slurpd.secret";
+  dbDirectory = "/var/db/openldap";
 in {
   services.openldap = {
     inherit rootpwFile;
@@ -15,6 +16,71 @@ in {
     rootdn = "cn=root,ou=ldap,o=redbrick";
     defaultSchemas = false; # We don't use the nis.schema
     database = "hdb";
+
+    settings = {
+      attrs = {
+        olcLogLevel = "0";
+        # Used in emergencies
+        # olcReadOnly = "TRUE";
+      };
+      children = {
+        "cn=schema".includes = [
+          "${pkgs.openldap.out}/etc/schema/core.schema"
+          "${pkgs.openldap.out}/etc/schema/cosine.schema"
+          "${pkgs.openldap.out}/etc/schema/inetorgperson.schema"
+          "${./schema/common.schema}"
+          "${./schema/system.schema}"
+          "${./schema/userdb.schema}"
+        ];
+        "olcDatabase={-1}frontend".attrs = {
+          objectClass = [ "olcDatabaseConfig" "olcFrontendConfig" ];
+          olcDatabase = "{-1}frontend";
+          olcSizeLimit = "unlimited";
+          olcLastMod = "TRUE";
+          olcAccess = [
+            "{0}to dn.children=ou=2002,ou=accounts,o=redbrick  by dn.regex=cn=root,ou=ldap,o=redbrick write  by dn.regex=cn=slurpd,ou=ldap,o=redbrick read by * none"
+            "{1}to dn.children=ou=accounts,o=redbrick  attrs=cn  by dn.regex=cn=root,ou=ldap,o=redbrick write  by dn.regex=cn=slurpd,ou=ldap,o=redbrick read  by dn.regex=cn=mediawiki,ou=reserved,o=redbrick read  by self read by * none"
+            "{2}to attrs=yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=root,ou=ldap,o=redbrick write  by dn.regex=cn=slurpd,ou=ldap,o=redbrick read  by dn.regex=cn=mediawiki,ou=reserved,o=redbrick read  by self read  by * none"
+            "{3}to attrs=userPassword  by dn.regex=cn=root,ou=ldap,o=redbrick write continue  by dn.regex=cn=slurpd,ou=ldap,o=redbrick read  by dn.regex=cn=dovecot,ou=reserved,o=redbrick read  by self write  by anonymous auth  by * none"
+            "{4}to attrs=gecos,loginShell  by dn.regex=cn=root,ou=ldap,o=redbrick write continue  by dn.regex=cn=slurpd,ou=ldap,o=redbrick read  by self write  by * read"
+            "{5}to *  by * read"
+          ];
+        };
+        "olcDatabase={0}config".attrs = {
+          objectClass = "olcDatabaseConfig";
+          olcDatabase = "{0}config";
+          olcAccess = [ "{0}to * by * none break" ];
+        };
+        "olcDatabase={1}hdb" = {
+          attrs = {
+            objectClass = [ "olcDatabaseConfig" "olcHdbConfig" ];
+            olcDatabase = "{1}hdb";
+            olcAccess = [ "{0}to * by * read break" ];
+            olcDbCacheSize = "100000";
+            olcLastMod = "TRUE";
+            olcMonitoring = "TRUE";
+            olcDbDirectory = dbDirectory;
+            olcSuffix = "o=redbrick";
+            olcRootDN = "cn=root,ou=ldap,o=redbrick";
+            olcRootPW = {
+              path = rootpwFile;
+            };
+          };
+          children = {
+            # TODO test + repl config
+            "olcOverlay={0}syncprov".attrs = if (config.redbrick.ldapSlaveTo == null) then {
+              objectClass = [ "olcOverlayConfig" "olcSyncProvConfig" ];
+              olcOverlay = "{0}syncprov";
+              olcSpCheckpoint = "100 10";
+              olcAccess = [ "{0}to * by * read break" ];
+            } else {
+              olcSyncrepl = "rid=000 provider=ldap://${config.redbrick.ldapSlaveTo}:389 bindmethod=simple timeout=0 network-timeout=0 binddn=\"cn=slurpd,ou=ldap,o=redbrick\" credentials=\"${lib.fileContents slurpdpwFile}\" keepalive=0:0:0 starttls=no filter=\"(objectclass=*)\" searchbase=\"o=redbrick\" scope=sub attrs=\"*,+\" schemachecking=off type=refreshAndPersist retry=\"5 5 300 +\"";
+              olcMirrorMode = "FALSE";
+            };
+          };
+      };
+    };
+
     extraDatabaseConfig = ''
       cachesize 100000
     '' + (if (config.redbrick.ldapSlaveTo == null) then ''

--- a/services/ldap/default.nix
+++ b/services/ldap/default.nix
@@ -42,9 +42,9 @@ in {
           olcSizeLimit = "unlimited";
           olcLastMod = "TRUE";
           olcAccess = [
-            "{0}to attrs=cn,yearsPaid,year,course,id,newbie,altmail  by dn.regex=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
-            "{1}to attrs=userPassword  by dn.regex=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
-            "{2}to attrs=gecos,loginShell  by self write  by * read"
+            "{0}to attrs=cn,yearsPaid,year,course,id,newbie,altmail  by dn.exact=${slurpdDN} manage  by dn.exact=cn=mediawiki,ou=reserved,${baseDN} read  by self read  by * none"
+            "{1}to attrs=userPassword  by dn.exact=${slurpdDN} manage  by dn.exact=cn=dovecot,ou=reserved,${baseDN} read  by self write  by anonymous auth  by * none"
+            "{2}to attrs=gecos,loginShell  by dn.exact=${slurpdDN} manage  by self write  by * read"
             "{3}to dn.subtree=${baseDN} by dn.exact=${slurpdDN} manage  by users read"
             "{4}to *  by * read"
           ];

--- a/services/ldap/initialise.ldif
+++ b/services/ldap/initialise.ldif
@@ -1,0 +1,15 @@
+dn: o=redbrick
+description: Redbrick DCU
+objectClass: top
+objectClass: organization
+
+dn: ou=services,o=redbrick
+objectClass: organizationalUnit
+ou: services
+
+dn: uid=slurpd,ou=services,o=redbrick
+objectClass: top
+objectClass: account
+objectClass: shadowAccount
+uid: slurpd
+userPassword:< file:///var/secrets/slurpd.secret

--- a/services/ldap/schema/common.ldif
+++ b/services/ldap/schema/common.ldif
@@ -1,3 +1,6 @@
+# AUTO-GENERATED FILE - DO NOT EDIT!! Use ldapmodify.
+# CRC32 c1213f10
+# Original comment:
 #
 # Redbrick User Database LDAP Schema
 #
@@ -10,8 +13,10 @@
 # User database information
 #
 # Attribute Type Definitions
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.1.1.1
+dn: cn=common,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: common
+olcAttributeTypes: {0}( 1.3.6.1.4.1.9736.15.1.1.1.1
         NAME ( 'username' )
         DESC 'A username'
         EQUALITY caseIgnoreMatch

--- a/services/ldap/schema/system.ldif
+++ b/services/ldap/schema/system.ldif
@@ -1,3 +1,6 @@
+# AUTO-GENERATED FILE - DO NOT EDIT!! Use ldapmodify.
+# CRC32 98c64a34
+# Original comment:
 #
 # Redbrick Account LDAP Schema
 #
@@ -14,105 +17,78 @@
 # OID Base is 1.3.6.1.4.1.9736.15.1.2 (See README for more)
 #
 # Attribute Type Definitions
-
-#attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.1 NAME 'uidNumber'
-#	DESC 'An integer uniquely identifying a user'
-#	EQUALITY integerMatch
-#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-#	SINGLE-VALUE )
-
-#attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.2 NAME 'gidNumber'
-#	DESC 'An integer uniquely identifying a group'
-#	EQUALITY integerMatch
-#	SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-#	SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.3 NAME 'gecos'
+dn: cn=system,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: system
+olcAttributeTypes: {0}( 1.3.6.1.4.1.9736.15.1.2.1.3 NAME 'gecos'
     DESC 'The GECOS field'
     EQUALITY caseIgnoreMatch
     SUBSTR caseIgnoreSubstringsMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.4 NAME 'homeDirectory'
+olcAttributeTypes: {1}( 1.3.6.1.4.1.9736.15.1.2.1.4 NAME 'homeDirectory'
     DESC 'The home directory'
     EQUALITY caseExactIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.5 NAME 'loginShell'
+olcAttributeTypes: {2}( 1.3.6.1.4.1.9736.15.1.2.1.5 NAME 'loginShell'
     DESC 'The login shell'
     EQUALITY caseExactIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.6 NAME 'shadowLastChange'
+olcAttributeTypes: {3}( 1.3.6.1.4.1.9736.15.1.2.1.6 NAME 'shadowLastChange'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.7 NAME 'shadowMin'
+olcAttributeTypes: {4}( 1.3.6.1.4.1.9736.15.1.2.1.7 NAME 'shadowMin'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.8 NAME 'shadowMax'
+olcAttributeTypes: {5}( 1.3.6.1.4.1.9736.15.1.2.1.8 NAME 'shadowMax'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.9 NAME 'shadowWarning'
+olcAttributeTypes: {6}( 1.3.6.1.4.1.9736.15.1.2.1.9 NAME 'shadowWarning'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.10 NAME 'shadowInactive'
+olcAttributeTypes: {7}( 1.3.6.1.4.1.9736.15.1.2.1.10 NAME 'shadowInactive'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.11 NAME 'shadowExpire'
+olcAttributeTypes: {8}( 1.3.6.1.4.1.9736.15.1.2.1.11 NAME 'shadowExpire'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.12 NAME 'shadowFlag'
+olcAttributeTypes: {9}( 1.3.6.1.4.1.9736.15.1.2.1.12 NAME 'shadowFlag'
     EQUALITY integerMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
     SINGLE-VALUE )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.13 NAME 'memberUid'
+olcAttributeTypes: {10}( 1.3.6.1.4.1.9736.15.1.2.1.13 NAME 'memberUid'
     EQUALITY caseExactIA5Match
     SUBSTR caseExactIA5SubstringsMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.14 NAME 'flag'
+olcAttributeTypes: {11}( 1.3.6.1.4.1.9736.15.1.2.1.14 NAME 'flag'
     DESC 'A generic flags associated with this user'
     EQUALITY caseIgnoreIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.15 NAME 'quota'
+olcAttributeTypes: {12}( 1.3.6.1.4.1.9736.15.1.2.1.15 NAME 'quota'
     DESC 'Quota information'
     EQUALITY caseIgnoreIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.2.1.16 NAME 'sambaPassword'
+olcAttributeTypes: {13}( 1.3.6.1.4.1.9736.15.1.2.1.16 NAME 'sambaPassword'
     DESC 'The samba password of user'
     EQUALITY octetStringMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.40{128}
     SINGLE-VALUE )
-
 # Object Class Definitions
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.2.2.1 NAME 'posixAccount'
+olcObjectClasses: {0}( 1.3.6.1.4.1.9736.15.1.2.2.1 NAME 'posixAccount'
     SUP top
     STRUCTURAL
     DESC 'An account with standard POSIX attributes'
     MUST ( uid $ uidNumber $ gidNumber $ homeDirectory $ userPassword $ loginShell )
     MAY ( cn $ gecos $ description $ flag $ quota $ sambaPassword ) )
-
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.2.2.2 NAME 'shadowAccount'
+olcObjectClasses: {1}( 1.3.6.1.4.1.9736.15.1.2.2.2 NAME 'shadowAccount'
     SUP top
     AUXILIARY
     DESC 'Standard shadow parameters'
@@ -120,15 +96,13 @@ objectclass ( 1.3.6.1.4.1.9736.15.1.2.2.2 NAME 'shadowAccount'
     MAY ( userPassword $ shadowLastChange $ shadowMin $
           shadowMax $ shadowWarning $ shadowInactive $
           shadowExpire $ shadowFlag $ description $ sambaPassword ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.2.2.3 NAME 'posixGroup'
+olcObjectClasses: {2}( 1.3.6.1.4.1.9736.15.1.2.2.3 NAME 'posixGroup'
     SUP top
     STRUCTURAL
     DESC 'A unix group'
     MUST ( cn $ gidNumber )
     MAY ( userPassword $ memberUid $ description ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.2.2.4 NAME 'dcuAccount'
+olcObjectClasses: {3}( 1.3.6.1.4.1.9736.15.1.2.2.4 NAME 'dcuAccount'
     SUP top
     STRUCTURAL
     DESC 'A DCU account'

--- a/services/ldap/schema/userdb.ldif
+++ b/services/ldap/schema/userdb.ldif
@@ -1,3 +1,6 @@
+# AUTO-GENERATED FILE - DO NOT EDIT!! Use ldapmodify.
+# CRC32 4987f42b
+# Original comment:
 #
 # Redbrick User Database LDAP Schema
 #
@@ -10,177 +13,141 @@
 # User database information
 #
 # Attribute Type Definitions
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.1 NAME 'photopath'
+dn: cn=userdb,cn=schema,cn=config
+objectClass: olcSchemaConfig
+cn: userdb
+olcAttributeTypes: {0}( 1.3.6.1.4.1.9736.15.1.3.1.1 NAME 'photopath'
     DESC 'The path to a photo'
     EQUALITY caseExactIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.2 NAME 'altmail'
+olcAttributeTypes: {1}( 1.3.6.1.4.1.9736.15.1.3.1.2 NAME 'altmail'
         DESC 'An alternate email address'
         EQUALITY caseIgnoreIA5Match
         SUBSTR caseIgnoreIA5SubstringsMatch
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{256} )
-
-attributetype (  1.3.6.1.4.1.9736.15.1.3.1.3 NAME 'newbie'
+olcAttributeTypes: {2}(  1.3.6.1.4.1.9736.15.1.3.1.3 NAME 'newbie'
         DESC 'A new account?'
         EQUALITY booleanMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.7 )
-
-attributetype (  1.3.6.1.4.1.9736.15.1.3.1.4 NAME 'id'
+olcAttributeTypes: {3}(  1.3.6.1.4.1.9736.15.1.3.1.4 NAME 'id'
         DESC 'An integer identifying number'
         EQUALITY integerMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
-
-attributetype (  1.3.6.1.4.1.9736.15.1.3.1.5 NAME 'course'
+olcAttributeTypes: {4}(  1.3.6.1.4.1.9736.15.1.3.1.5 NAME 'course'
         DESC 'A course identifier'
         EQUALITY caseIgnoreIA5Match
         SUBSTR caseIgnoreIA5SubstringsMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26{5} )
-
-attributetype (  1.3.6.1.4.1.9736.15.1.3.1.6 NAME 'date'
+olcAttributeTypes: {5}(  1.3.6.1.4.1.9736.15.1.3.1.6 NAME 'date'
     DESC 'A representation of a date'
     EQUALITY caseIgnoreIA5Match
     SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
 # Various boring attributes, important that each one have a different
 # oid otherwise they're counted as one single entity, which means
 # MUST clauses only take one of them.
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.6.1 NAME 'created'
+olcAttributeTypes: {6}( 1.3.6.1.4.1.9736.15.1.3.1.6.1 NAME 'created'
     SUP date )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.6.2 NAME 'updated'
+olcAttributeTypes: {7}( 1.3.6.1.4.1.9736.15.1.3.1.6.2 NAME 'updated'
     SUP date )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.6.3 NAME 'birthday'
+olcAttributeTypes: {8}( 1.3.6.1.4.1.9736.15.1.3.1.6.3 NAME 'birthday'
     SUP date )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.7.1 NAME 'createdby'
+olcAttributeTypes: {9}( 1.3.6.1.4.1.9736.15.1.3.7.1 NAME 'createdby'
     SUP username )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.7.2 NAME 'updatedby'
+olcAttributeTypes: {10}( 1.3.6.1.4.1.9736.15.1.3.7.2 NAME 'updatedby'
     SUP username )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.8 NAME 'year'
+olcAttributeTypes: {11}( 1.3.6.1.4.1.9736.15.1.3.1.8 NAME 'year'
         DESC 'A college year 1-4/C/X'
         EQUALITY caseIgnoreIA5Match
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
-
-attributetype ( 1.3.6.1.4.1.9736.15.1.3.1.9 NAME 'yearsPaid'
+olcAttributeTypes: {12}( 1.3.6.1.4.1.9736.15.1.3.1.9 NAME 'yearsPaid'
         DESC 'Number of years paid by this user'
         ORDERING integerOrderingMatch
     EQUALITY integerMatch
         SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )
-
 # Object Class Definitions
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.1 NAME 'userdb'
+olcObjectClasses: {0}( 1.3.6.1.4.1.9736.15.1.3.2.1 NAME 'userdb'
     SUP top
     ABSTRACT
     DESC 'User database information'
     MUST ( cn $ altmail $ newbie $ created $ createdby $ updated $ updatedby )
     MAY ( sn $ description $ photopath $ course $ year $ id $ birthday $ host $ yearsPaid $ flag ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.2 NAME 'payinguser'
+olcObjectClasses: {1}( 1.3.6.1.4.1.9736.15.1.3.2.2 NAME 'payinguser'
     SUP userdb
     AUXILIARY
     DESC 'A paying user account'
     MUST ( yearsPaid ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.3 NAME 'payingdcuuser'
+olcObjectClasses: {2}( 1.3.6.1.4.1.9736.15.1.3.2.3 NAME 'payingdcuuser'
     SUP payinguser
     AUXILIARY
     DESC 'A paying DCU user account'
     MUST ( id ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.4 NAME 'associat'
+olcObjectClasses: {3}( 1.3.6.1.4.1.9736.15.1.3.2.4 NAME 'associat'
     SUP payingdcuuser
     AUXILIARY
     DESC 'A Redbrick associat' )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.5 NAME 'staff'
+olcObjectClasses: {4}( 1.3.6.1.4.1.9736.15.1.3.2.5 NAME 'staff'
     SUP payingdcuuser
     AUXILIARY
     DESC 'A DCU staff member' )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.7 NAME 'studentuser'
+olcObjectClasses: {5}( 1.3.6.1.4.1.9736.15.1.3.2.7 NAME 'studentuser'
     SUP payingdcuuser
     AUXILIARY
     DESC 'A DCU student'
     MUST ( year $ course ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.8 NAME 'committe'
+olcObjectClasses: {6}( 1.3.6.1.4.1.9736.15.1.3.2.8 NAME 'committe'
     SUP studentuser
     AUXILIARY
     DESC 'Committee member' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.9 NAME 'member'
+olcObjectClasses: {7}( 1.3.6.1.4.1.9736.15.1.3.2.9 NAME 'member'
     SUP studentuser
     AUXILIARY
     DESC 'Run o-the-mill member' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.10 NAME 'freeuser'
+olcObjectClasses: {8}( 1.3.6.1.4.1.9736.15.1.3.2.10 NAME 'freeuser'
     SUP userdb
     AUXILIARY
     DESC 'Non paying user' ) )
-
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.6 NAME 'founders'
+olcObjectClasses: {9}( 1.3.6.1.4.1.9736.15.1.3.2.6 NAME 'founders'
     SUP freeuser
     AUXILIARY
     DESC 'A Redbrick founder' )
-
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.11 NAME 'redbrick'
+olcObjectClasses: {10}( 1.3.6.1.4.1.9736.15.1.3.2.11 NAME 'redbrick'
     SUP freeuser
     AUXILIARY
     DESC 'Redbrick user type' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.12 NAME 'reserved'
+olcObjectClasses: {11}( 1.3.6.1.4.1.9736.15.1.3.2.12 NAME 'reserved'
     STRUCTURAL
     MUST ( description $ uid )
     MAY ( cn $ flag )
     DESC 'Reserved user type' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.13 NAME 'system'
+olcObjectClasses: {12}( 1.3.6.1.4.1.9736.15.1.3.2.13 NAME 'system'
     SUP freeuser
     AUXILIARY
     DESC 'System user type' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.14 NAME 'dcu'
+olcObjectClasses: {13}( 1.3.6.1.4.1.9736.15.1.3.2.14 NAME 'dcu'
     SUP freeuser
     AUXILIARY
     DESC 'DCU user type' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.15 NAME 'guest'
+olcObjectClasses: {14}( 1.3.6.1.4.1.9736.15.1.3.2.15 NAME 'guest'
     SUP userdb
     AUXILIARY
     DESC 'Guest user type' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.16 NAME 'intersoc'
+olcObjectClasses: {15}( 1.3.6.1.4.1.9736.15.1.3.2.16 NAME 'intersoc'
     SUP freeuser
     AUXILIARY
     DESC 'Intersocs user' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.17 NAME 'club'
+olcObjectClasses: {16}( 1.3.6.1.4.1.9736.15.1.3.2.17 NAME 'club'
     SUP freeuser
     AUXILIARY
     DESC 'DCU Club user' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.18 NAME 'society'
+olcObjectClasses: {17}( 1.3.6.1.4.1.9736.15.1.3.2.18 NAME 'society'
     SUP freeuser
     AUXILIARY
     DESC 'DCU Society user' ) )
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.19 NAME 'projects'
+olcObjectClasses: {18}( 1.3.6.1.4.1.9736.15.1.3.2.19 NAME 'projects'
     SUP freeuser
     AUXILIARY
     DESC 'Redbrick project user' ) )
-
 # Extra non standard
-
-objectclass ( 1.3.6.1.4.1.9736.15.1.3.2.20 NAME 'admin'
+olcObjectClasses: {19}( 1.3.6.1.4.1.9736.15.1.3.2.20 NAME 'admin'
     SUP userdb
     AUXILIARY )
-

--- a/services/rbbackup.nix
+++ b/services/rbbackup.nix
@@ -1,0 +1,41 @@
+{ pkgs, config, lib, ... }:
+with config.redbrick.rbbackup;
+let
+  # Quote and join paths for arguments to rsync
+  sourcePaths = lib.concatStringsSep " " (builtins.map
+    (srcPath: "'${srcPath}'")
+    sources);
+
+in lib.mkIf (sources != []) {
+  systemd.services.redbrick-backup = {
+    aliases = [ "rbbackup.service" "redbrick-backups.service" ];
+    description = "Redbrick backup script. Copies data to ${destination}";
+    wants = [ "multi-user.target" ];
+    requires = [ "local-fs.target" "network-online.target" ];
+    path = with pkgs; [ rsync openssh ] ++ extraPackages;
+    script = ''
+      set -euxo pipefail
+      echo "Backup starting"
+      rsync -a --progress --delete ${sourcePaths} ${destination}
+      echo "Backup successful"
+    '';
+    preStart = commands;
+    postStart = ''
+      rm -rf $CACHE_DIRECTORY
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      CacheDirectory = "redbrick-backups";
+      WorkingDirectory = "/var/cache/redbrick-backups";
+    };
+  };
+
+  systemd.timers.redbrick-backup = {
+    description = "Start Redbrick backup script";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnCalendar = "hourly";
+      RandomizedDelaySec = 60 * 30;
+    };
+  };
+}

--- a/services/redis.nix
+++ b/services/redis.nix
@@ -14,11 +14,11 @@
     logfile = "/var/log/redis/redis.log";
     syslog = false;
 
-    extraConfig = ''
-      rdbcompression yes
-      maxmemory 2G
-      maxmemory-policy allkeys-lru
-      unixsocketperm 660
-    '';
+    settings = {
+      rdbcompression = "yes";
+      maxmemory = "2G";
+      maxmemory-policy = "allkeys-lru";
+      unixsocketperm = "660";
+    };
   };
 }

--- a/services/znapzend.nix
+++ b/services/znapzend.nix
@@ -12,7 +12,7 @@
       plan = "1d=>1h,1m=>1d,6m=>1m";
       recursive = true;
       destinations.albus = {
-        host = "znapzend@albus.internal";
+        host = "rbbackup@albus.internal";
         dataset = config.redbrick.znapzendDestDataset;
       };
     };


### PR DESCRIPTION
LDAP servers are now configured for multi-master replication, and the config supports multiple different clusters existing.

I have also built an rbbackup service which can be conveniently configured to run scripts and back up files to Albus every hour. Albus will then store snapshots of the filesystem, which can be used to retrieve backups up to 3 months ago.