### PR TITLE
Rbbackup updates

### DIFF
--- a/hosts/albus/configuration.nix
+++ b/hosts/albus/configuration.nix
@@ -32,6 +32,8 @@ in {
 
   # Keep longer monthly snapshots
   services.zfs.autoSnapshot.monthly = lib.mkForce 3;
+  services.zfs.autoSnapshot.hourly = lib.mkForce 23;
+  services.zfs.autoSnapshot.frequent = lib.mkForce 2;
 
   # Albus _is_ the backup hosts - change rbbackup destination
   redbrick.rbbackup.destination = "/zbackup/generic/albus/";

--- a/services/rbbackup.nix
+++ b/services/rbbackup.nix
@@ -27,6 +27,7 @@ in lib.mkIf (sources != []) {
       Type = "oneshot";
       CacheDirectory = "redbrick-backups";
       WorkingDirectory = "/var/cache/redbrick-backups";
+      UMask = 0077;
     };
   };
 


### PR DESCRIPTION
- Set umask to 0077 to ensure that files created during the backup
  process are not world readable (as they would generally contain
  sensitive info)
- Changed Snapshot policies on Albus to keep 23 hourly snapshots and
  2 quarter-hourly snasphots.